### PR TITLE
fix: make createMonitor/updateMonitor actually apply tags

### DIFF
--- a/src/uptime-kuma-client.ts
+++ b/src/uptime-kuma-client.ts
@@ -756,51 +756,182 @@ export class UptimeKumaClient {
   // ─── Monitor write operations ───────────────────────────────────────────────
 
   /**
-   * Create a new monitor
+   * Create a new monitor. If `tags` are supplied, they are applied after
+   * creation using the separate `addMonitorTag` socket event — the `add`
+   * socket handler does not process tags.
    *
    * @param monitorData - Monitor configuration (type-specific fields should be included)
    * @returns Promise resolving to the API response with the new monitorID
    */
-  createMonitor(monitorData: Record<string, unknown>): Promise<ApiResponse & { monitorID?: number }> {
-    return new Promise((resolve, reject) => {
+  async createMonitor(monitorData: Record<string, unknown>): Promise<ApiResponse & { monitorID?: number }> {
+    const { tags, ...payload } = monitorData as { tags?: Array<Record<string, unknown>> };
+
+    const response = await new Promise<ApiResponse & { monitorID?: number }>((resolve, reject) => {
       if (!this.socket || !this.socket.connected) {
         reject(new Error('Not connected to server'));
         return;
       }
 
-      this.socket.emit('add', monitorData, (response: ApiResponse & { monitorID?: number }) => {
-        if (response.ok) {
-          this.safeLog('info', `Successfully created monitor (ID: ${response.monitorID})`);
-          resolve(response);
+      this.socket.emit('add', payload, (res: ApiResponse & { monitorID?: number }) => {
+        if (res.ok) {
+          this.safeLog('info', `Successfully created monitor (ID: ${res.monitorID})`);
+          resolve(res);
         } else {
-          reject(new Error(response.msg || 'Failed to create monitor'));
+          reject(new Error(res.msg || 'Failed to create monitor'));
+        }
+      });
+    });
+
+    if (tags && Array.isArray(tags) && response.monitorID != null) {
+      await this.reconcileMonitorTags(response.monitorID, tags);
+    }
+
+    return response;
+  }
+
+  /**
+   * Update an existing monitor. If `tags` are supplied, they are reconciled
+   * against the monitor's current tag set using `addMonitorTag` /
+   * `deleteMonitorTag` — the `editMonitor` socket handler does not process
+   * tags. Tags whose name is not yet in the catalog are auto-created via
+   * `addTag` before binding.
+   *
+   * @param monitorData - Monitor configuration including the id field
+   * @returns Promise resolving to the API response
+   */
+  async updateMonitor(monitorData: Record<string, unknown>): Promise<ApiResponse & { monitorID?: number }> {
+    const { tags, ...payload } = monitorData as { tags?: Array<Record<string, unknown>> };
+
+    const response = await new Promise<ApiResponse & { monitorID?: number }>((resolve, reject) => {
+      if (!this.socket || !this.socket.connected) {
+        reject(new Error('Not connected to server'));
+        return;
+      }
+
+      this.socket.emit('editMonitor', payload, (res: ApiResponse & { monitorID?: number }) => {
+        if (res.ok) {
+          this.safeLog('info', `Successfully updated monitor (ID: ${monitorData['id']})`);
+          resolve(res);
+        } else {
+          reject(new Error(res.msg || 'Failed to update monitor'));
+        }
+      });
+    });
+
+    if (tags && Array.isArray(tags) && monitorData['id'] != null) {
+      await this.reconcileMonitorTags(Number(monitorData['id']), tags);
+    }
+
+    return response;
+  }
+
+  /**
+   * Fetch the tag catalog synchronously from the server. Uptime Kuma does
+   * not push `tagList` events — it only responds to the `getTags` request —
+   * so relying on the push-populated cache returns stale (often empty) data.
+   * This method also refreshes `tagListCache` so subsequent cache reads work.
+   */
+  private fetchTagList(): Promise<Array<{ id: number; name: string; color: string }>> {
+    return new Promise((resolve, reject) => {
+      if (!this.socket || !this.socket.connected) {
+        reject(new Error('Not connected to server'));
+        return;
+      }
+      this.socket.emit('getTags', (res: ApiResponse & { tags?: Array<{ id: number; name: string; color: string }> }) => {
+        if (res.ok && res.tags) {
+          this.tagListCache = res.tags;
+          resolve(res.tags);
+        } else {
+          reject(new Error(res.msg || 'Failed to fetch tag list'));
         }
       });
     });
   }
 
   /**
-   * Update an existing monitor
-   *
-   * @param monitorData - Monitor configuration including the id field
-   * @returns Promise resolving to the API response
+   * Bind a tag to a monitor (socket: `addMonitorTag`).
    */
-  updateMonitor(monitorData: Record<string, unknown>): Promise<ApiResponse & { monitorID?: number }> {
+  private addMonitorTag(tagID: number, monitorID: number, value: string): Promise<ApiResponse> {
     return new Promise((resolve, reject) => {
       if (!this.socket || !this.socket.connected) {
         reject(new Error('Not connected to server'));
         return;
       }
-
-      this.socket.emit('editMonitor', monitorData, (response: ApiResponse & { monitorID?: number }) => {
-        if (response.ok) {
-          this.safeLog('info', `Successfully updated monitor (ID: ${monitorData['id']})`);
-          resolve(response);
-        } else {
-          reject(new Error(response.msg || 'Failed to update monitor'));
-        }
+      this.socket.emit('addMonitorTag', tagID, monitorID, value, (res: ApiResponse) => {
+        if (res.ok) resolve(res);
+        else reject(new Error(res.msg || `Failed to add tag ${tagID} to monitor ${monitorID}`));
       });
     });
+  }
+
+  /**
+   * Unbind a tag from a monitor (socket: `deleteMonitorTag`).
+   */
+  private deleteMonitorTag(tagID: number, monitorID: number, value: string): Promise<ApiResponse> {
+    return new Promise((resolve, reject) => {
+      if (!this.socket || !this.socket.connected) {
+        reject(new Error('Not connected to server'));
+        return;
+      }
+      this.socket.emit('deleteMonitorTag', tagID, monitorID, value, (res: ApiResponse) => {
+        if (res.ok) resolve(res);
+        else reject(new Error(res.msg || `Failed to remove tag ${tagID} from monitor ${monitorID}`));
+      });
+    });
+  }
+
+  /**
+   * Reconcile a monitor's tags against the desired list. Auto-creates any
+   * tag name that isn't yet in the catalog. Tag identity is `(name, value)`.
+   */
+  private async reconcileMonitorTags(
+    monitorID: number,
+    desiredTags: Array<Record<string, unknown>>
+  ): Promise<void> {
+    const currentMonitor = this.monitorListCache[String(monitorID)];
+    const currentTags = (currentMonitor?.tags ?? []) as Array<{
+      tag_id?: number;
+      name: string;
+      value?: string;
+      color?: string;
+    }>;
+
+    const key = (name: string, value: string | undefined) => `${name}\u0000${value ?? ''}`;
+    const currentKeys = new Set(currentTags.map((t) => key(t.name, t.value)));
+    const desiredKeys = new Set(
+      desiredTags.map((t) => key(String(t.name), t.value as string | undefined))
+    );
+
+    // Uptime Kuma never pushes `tagList` events, so the cache is unreliable
+    // — fetch the catalog synchronously via the `getTags` socket request.
+    const freshTags = await this.fetchTagList();
+    const nameToID = new Map<string, number>();
+    for (const t of freshTags) nameToID.set(t.name, t.id);
+
+    for (const desired of desiredTags) {
+      const name = String(desired.name);
+      const value = (desired.value as string | undefined) ?? '';
+      if (currentKeys.has(key(name, value))) continue;
+
+      let tagID = nameToID.get(name);
+      if (tagID == null) {
+        const color = (desired.color as string | undefined) ?? '#808080';
+        const created = await this.addTag(name, color);
+        tagID = created.tag?.id;
+        if (tagID != null) nameToID.set(name, tagID);
+      }
+      if (tagID == null) {
+        throw new Error(`Could not resolve tag ID for "${name}"`);
+      }
+      await this.addMonitorTag(tagID, monitorID, value);
+    }
+
+    for (const existing of currentTags) {
+      if (desiredKeys.has(key(existing.name, existing.value))) continue;
+      const tagID = existing.tag_id ?? nameToID.get(existing.name);
+      if (tagID == null) continue;
+      await this.deleteMonitorTag(tagID, monitorID, existing.value ?? '');
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

The `tags` field on `createMonitor` / `updateMonitor` is silently dropped — the underlying Uptime Kuma `add` and `editMonitor` socket handlers do not process tags. Callers see `ok: true` but the monitor stays untagged.

This PR makes the declarative `tags` field actually work by reconciling tags at the client layer, matching how `notificationIDList` already works (Uptime Kuma's `editMonitor` handler calls `updateMonitorNotification` internally — we do the equivalent for tags here).

## What changed

- `UptimeKumaClient.createMonitor` and `updateMonitor` now strip `tags` from the `add`/`editMonitor` payload, then reconcile separately against the monitor's current tag set
- Tag identity is `(name, value)` — the same key pair Uptime Kuma's UI uses
- Added private helpers: `addMonitorTag(tagID, monitorID, value)`, `deleteMonitorTag(tagID, monitorID, value)` wrapping the corresponding socket events
- Tag names not yet in the catalog are auto-created via `addTag` before binding, so a caller can pass a brand-new `{name, value, color}` and it just works
- No new public MCP tools — the existing `tags` parameter just does the right thing now

## Root cause (from Uptime Kuma source)

`server/server.js` shows `editMonitor` (line 800) reads individual fields (`bean.name = monitor.name`, `bean.url = monitor.url`, …) but never touches `tags`. Tag membership lives on separate socket events:

- `addMonitorTag(tagID, monitorID, value, callback)` — line 1282
- `editMonitorTag(...)` — line 1307
- `deleteMonitorTag(...)` — line 1332

## Test plan

Tested against a real Uptime Kuma v2 instance:

- [x] `updateMonitor` with `tags: [{name: "type", value: "host", color: "#3b82f6"}]` on a previously-untagged monitor → tag appears in UI and subsequent `listMonitors` response
- [x] `updateMonitor` with a tag whose name did not exist in the catalog → tag auto-created, then bound
- [x] `updateMonitor` with `tags: []` on a tagged monitor → all tags removed
- [x] `updateMonitor` with a different `value` for the same tag name → old (name, value) pair removed, new one added
- [x] `createMonitor` with `tags: [...]` → monitor created with tags bound in one call

🤖 Generated with [Claude Code](https://claude.com/claude-code)