### PR TITLE
feat: add Docker host CRUD tools

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { McpError, ErrorCode, SetLevelRequestSchema, LoggingLevelSchema, type LoggingLevel } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { UptimeKumaClient } from './uptime-kuma-client.js';
-import { HeartbeatSchema, MonitorBaseSchema, MonitorSummarySchema, SettingsSchema, NotificationSchema, MaintenanceSchema, StatusPageSchema } from './types/index.js';
+import { HeartbeatSchema, MonitorBaseSchema, MonitorSummarySchema, SettingsSchema, NotificationSchema, MaintenanceSchema, StatusPageSchema, DockerHostSchema } from './types/index.js';
 import type { UptimeKumaConfig } from './types/index.js';
 import { VERSION } from './version.js';
 
@@ -31,12 +31,15 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         - Use 'listTags' to see available tags.
         - Use 'getMaintenanceWindows' to see scheduled maintenance.
         - Use 'listStatusPages' to see status page configurations.
+        - Use 'listDockerHosts' to see configured docker daemons (used by docker container monitors).
 
         WRITE operations:
         - Use 'createMonitor' / 'updateMonitor' / 'deleteMonitor' to manage monitors.
         - Use 'addNotification' / 'updateNotification' / 'deleteNotification' to manage notification channels.
         - Use 'addTag' / 'deleteTag' to manage tags.
         - Use 'createMaintenance' to schedule a maintenance window.
+        - Use 'addDockerHost' / 'updateDockerHost' / 'deleteDockerHost' to manage docker daemon connections.
+        - Use 'testDockerHost' to verify a docker daemon is reachable before saving.
         - Use 'pauseMonitor' / 'resumeMonitor' to temporarily stop/start checks.
       `,
       capabilities: {
@@ -822,6 +825,184 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
         throw new McpError(ErrorCode.InternalError, `Failed to delete notification: ${errorMessage}`);
+      }
+    }
+  );
+
+  // ─── Docker host tools ───────────────────────────────────────────────────
+
+  server.registerTool(
+    'listDockerHosts',
+    {
+      title: 'List Docker Hosts',
+      description: 'Returns all docker daemon connections configured in Uptime Kuma. These are referenced by docker container monitors via docker_host.',
+      inputSchema: {},
+      outputSchema: {
+        dockerHosts: z.array(DockerHostSchema).describe('Array of docker host configurations'),
+        count: z.number(),
+      },
+    },
+    async () => {
+      if (!isAuthenticated) {
+        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
+      }
+
+      try {
+        const dockerHosts = client.getDockerHostList();
+        return {
+          content: [{ type: 'text', text: JSON.stringify(dockerHosts, null, 2) }],
+          structuredContent: { dockerHosts, count: dockerHosts.length },
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        throw new McpError(ErrorCode.InternalError, `Failed to list docker hosts: ${errorMessage}`);
+      }
+    }
+  );
+
+  server.registerTool(
+    'addDockerHost',
+    {
+      title: 'Add Docker Host',
+      description: 'Creates a new docker daemon connection. For a unix socket use dockerType="socket" and dockerDaemon="/var/run/docker.sock". For a TCP proxy (e.g. tecnativa/docker-socket-proxy) use dockerType="tcp" and dockerDaemon="http://host:2375". Consider calling testDockerHost first to verify reachability.',
+      inputSchema: {
+        name: z.string().describe('Human-readable name for this docker host'),
+        dockerType: z.enum(['socket', 'tcp']).describe('"socket" for a unix socket path, "tcp" for an HTTP/HTTPS URL'),
+        dockerDaemon: z.string().describe('Unix socket path (e.g. /var/run/docker.sock) when dockerType=socket, or TCP URL (e.g. http://docker-proxy:2375) when dockerType=tcp'),
+      },
+      outputSchema: {
+        ok: z.boolean(),
+        id: z.number().optional(),
+        msg: z.string().optional(),
+      },
+    },
+    async ({ name, dockerType, dockerDaemon }) => {
+      if (!isAuthenticated) {
+        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
+      }
+
+      try {
+        const response = await client.addDockerHost({ name, dockerType, dockerDaemon });
+        return {
+          content: [{ type: 'text', text: response.msg || `Docker host created with ID ${response.id}` }],
+          structuredContent: { ok: response.ok, id: response.id, msg: response.msg },
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        throw new McpError(ErrorCode.InternalError, `Failed to add docker host: ${errorMessage}`);
+      }
+    }
+  );
+
+  server.registerTool(
+    'updateDockerHost',
+    {
+      title: 'Update Docker Host',
+      description: 'Updates an existing docker daemon connection. Use listDockerHosts to find the docker host ID. Only the fields you pass are changed — the others are preserved.',
+      inputSchema: {
+        dockerHostID: z.coerce.number().int().nonnegative().describe('The ID of the docker host to update'),
+        name: z.string().optional().describe('New human-readable name'),
+        dockerType: z.enum(['socket', 'tcp']).optional().describe('New connection type'),
+        dockerDaemon: z.string().optional().describe('New socket path or TCP URL'),
+      },
+      outputSchema: {
+        ok: z.boolean(),
+        id: z.number().optional(),
+        msg: z.string().optional(),
+      },
+    },
+    async ({ dockerHostID, name, dockerType, dockerDaemon }) => {
+      if (!isAuthenticated) {
+        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
+      }
+
+      try {
+        // Merge new values onto the current record so callers can omit unchanged fields.
+        // Uptime Kuma's addDockerHost handler overwrites every column it receives, so we
+        // need to send the full set to avoid clobbering existing values with undefined.
+        const existing = client.getDockerHostList().find(h => h.id === dockerHostID);
+        if (!existing) {
+          throw new Error(`Docker host ${dockerHostID} not found — call listDockerHosts to see available IDs`);
+        }
+
+        const merged: Record<string, unknown> = {
+          name: name ?? existing.name,
+          dockerType: dockerType ?? existing.dockerType,
+          dockerDaemon: dockerDaemon ?? existing.dockerDaemon,
+        };
+
+        const response = await client.addDockerHost(merged, dockerHostID);
+        return {
+          content: [{ type: 'text', text: response.msg || `Docker host ${dockerHostID} updated` }],
+          structuredContent: { ok: response.ok, id: response.id, msg: response.msg },
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        throw new McpError(ErrorCode.InternalError, `Failed to update docker host: ${errorMessage}`);
+      }
+    }
+  );
+
+  server.registerTool(
+    'deleteDockerHost',
+    {
+      title: 'Delete Docker Host',
+      description: 'Permanently deletes a docker daemon connection. Any monitors referencing it will have their docker_host cleared by Uptime Kuma (the monitors themselves are not deleted).',
+      inputSchema: {
+        dockerHostID: z.coerce.number().int().nonnegative().describe('The ID of the docker host to delete'),
+      },
+      outputSchema: {
+        ok: z.boolean(),
+        msg: z.string().optional(),
+      },
+    },
+    async ({ dockerHostID }) => {
+      if (!isAuthenticated) {
+        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
+      }
+
+      try {
+        const response = await client.deleteDockerHost(dockerHostID);
+        return {
+          content: [{ type: 'text', text: response.msg || `Docker host ${dockerHostID} deleted` }],
+          structuredContent: { ok: response.ok, msg: response.msg },
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        throw new McpError(ErrorCode.InternalError, `Failed to delete docker host: ${errorMessage}`);
+      }
+    }
+  );
+
+  server.registerTool(
+    'testDockerHost',
+    {
+      title: 'Test Docker Host',
+      description: 'Tests connectivity to a docker daemon without persisting it. On success the message includes the number of containers. Use this before addDockerHost to avoid saving a broken configuration.',
+      inputSchema: {
+        name: z.string().describe('Display name (used only in the test request)'),
+        dockerType: z.enum(['socket', 'tcp']).describe('"socket" for a unix socket path, "tcp" for an HTTP/HTTPS URL'),
+        dockerDaemon: z.string().describe('Unix socket path or TCP URL to probe'),
+      },
+      outputSchema: {
+        ok: z.boolean(),
+        msg: z.string().optional(),
+      },
+    },
+    async ({ name, dockerType, dockerDaemon }) => {
+      if (!isAuthenticated) {
+        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
+      }
+
+      try {
+        const response = await client.testDockerHost({ name, dockerType, dockerDaemon });
+        return {
+          content: [{ type: 'text', text: response.msg || (response.ok ? 'Docker host reachable' : 'Docker host unreachable') }],
+          structuredContent: { ok: response.ok, msg: response.msg },
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        throw new McpError(ErrorCode.InternalError, `Failed to test docker host: ${errorMessage}`);
       }
     }
   );

--- a/src/types/docker-host.ts
+++ b/src/types/docker-host.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+/**
+ * Docker host (docker daemon connection) configuration schema
+ * Used by monitors of type "docker" to specify which daemon to query.
+ */
+export const DockerHostSchema = z.object({
+  id: z.number().optional().describe('Docker host ID (assigned by server)'),
+  userID: z.number().optional().describe('Owner user ID (set by server)'),
+  name: z.string().optional().describe('Human-readable name for this docker host'),
+  dockerType: z.enum(['socket', 'tcp']).optional().describe('Connection type: "socket" for a unix socket path, "tcp" for an HTTP/HTTPS URL'),
+  dockerDaemon: z.string().optional().describe('Unix socket path (e.g. /var/run/docker.sock) when dockerType=socket, or TCP URL (e.g. http://docker-proxy:2375) when dockerType=tcp'),
+}).passthrough();
+
+export type DockerHost = z.infer<typeof DockerHostSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,3 +37,6 @@ export * from './maintenance.js';
 
 // Status page schemas
 export * from './status-page.js';
+
+// Docker host schemas
+export * from './docker-host.js';

--- a/src/uptime-kuma-client.ts
+++ b/src/uptime-kuma-client.ts
@@ -19,6 +19,7 @@ import type {
   Notification,
   Maintenance,
   StatusPage,
+  DockerHost,
 } from './types/index.js';
 
 /**
@@ -60,6 +61,7 @@ export class UptimeKumaClient {
   private tagListCache: Array<{ id: number; name: string; color: string }> = [];
   private maintenanceListCache: { [id: string]: Maintenance } = {};
   private statusPageListCache: { [slug: string]: StatusPage } = {};
+  private dockerHostListCache: DockerHost[] = [];
   private server?: { sendLoggingMessage: (params: { level: LoggingLevel; data: unknown }) => Promise<void> };
   private shouldLog: (level: LoggingLevel) => boolean;
   private loginCredentials: { username: string | undefined; password: string | undefined; token?: string; jwtToken?: string } | null = null;
@@ -176,6 +178,7 @@ export class UptimeKumaClient {
       this.socket.off('tagList');
       this.socket.off('maintenanceList');
       this.socket.off('statusPageList');
+      this.socket.off('dockerHostList');
 
       this.socket.disconnect();
       this.socket = null;
@@ -190,6 +193,7 @@ export class UptimeKumaClient {
     this.tagListCache = [];
     this.maintenanceListCache = {};
     this.statusPageListCache = {};
+    this.dockerHostListCache = [];
   }
 
   /**
@@ -220,6 +224,7 @@ export class UptimeKumaClient {
       this.setupTagListListeners();
       this.setupMaintenanceListListeners();
       this.setupStatusPageListListeners();
+      this.setupDockerHostListListeners();
 
       // If JWT token is provided, use token-based authentication
       if (jwtToken) {
@@ -753,6 +758,14 @@ export class UptimeKumaClient {
     });
   }
 
+  private setupDockerHostListListeners(): void {
+    if (!this.socket) return;
+    this.socket.on('dockerHostList', (dockerHostList: DockerHost[]) => {
+      this.safeLog('debug', `Received dockerHostList with ${dockerHostList.length} docker hosts`);
+      this.dockerHostListCache = dockerHostList;
+    });
+  }
+
   // ─── Monitor write operations ───────────────────────────────────────────────
 
   /**
@@ -882,6 +895,89 @@ export class UptimeKumaClient {
         } else {
           reject(new Error(response.msg || 'Failed to delete notification'));
         }
+      });
+    });
+  }
+
+  // ─── Docker host operations ─────────────────────────────────────────────────
+
+  /**
+   * Get the cached docker host list
+   */
+  getDockerHostList(): DockerHost[] {
+    return this.dockerHostListCache;
+  }
+
+  /**
+   * Add or update a docker host
+   *
+   * @param dockerHost - Docker host configuration (name, dockerType, dockerDaemon)
+   * @param dockerHostID - If provided, updates existing; otherwise creates new
+   * @returns Promise resolving to the API response with the docker host id
+   */
+  addDockerHost(dockerHost: Record<string, unknown>, dockerHostID?: number): Promise<ApiResponse & { id?: number }> {
+    return new Promise((resolve, reject) => {
+      if (!this.socket || !this.socket.connected) {
+        reject(new Error('Not connected to server'));
+        return;
+      }
+
+      const id = dockerHostID ?? null;
+      this.socket.emit('addDockerHost', dockerHost, id, (response: ApiResponse & { id?: number }) => {
+        if (response.ok) {
+          this.safeLog('info', `Successfully saved docker host (ID: ${response.id})`);
+          resolve(response);
+        } else {
+          reject(new Error(response.msg || 'Failed to save docker host'));
+        }
+      });
+    });
+  }
+
+  /**
+   * Delete a docker host. Any monitors referencing it will have their docker_host
+   * field cleared by Uptime Kuma.
+   *
+   * @param dockerHostID - The ID of the docker host to delete
+   * @returns Promise resolving to the API response
+   */
+  deleteDockerHost(dockerHostID: number): Promise<ApiResponse> {
+    return new Promise((resolve, reject) => {
+      if (!this.socket || !this.socket.connected) {
+        reject(new Error('Not connected to server'));
+        return;
+      }
+
+      this.socket.emit('deleteDockerHost', dockerHostID, (response: ApiResponse) => {
+        if (response.ok) {
+          this.safeLog('info', `Successfully deleted docker host ${dockerHostID}`);
+          resolve(response);
+        } else {
+          reject(new Error(response.msg || 'Failed to delete docker host'));
+        }
+      });
+    });
+  }
+
+  /**
+   * Test connectivity to a docker host without persisting it. Returns a friendly
+   * message containing the number of containers when reachable.
+   *
+   * @param dockerHost - Docker host configuration to test (name, dockerType, dockerDaemon)
+   * @returns Promise resolving to the API response
+   */
+  testDockerHost(dockerHost: Record<string, unknown>): Promise<ApiResponse> {
+    return new Promise((resolve, reject) => {
+      if (!this.socket || !this.socket.connected) {
+        reject(new Error('Not connected to server'));
+        return;
+      }
+
+      this.socket.emit('testDockerHost', dockerHost, (response: ApiResponse) => {
+        // Resolve either way so callers can inspect ok/msg without try/catch
+        // (matches the pattern used by UK's UI, which shows both success and
+        // failure messages from the same callback).
+        resolve(response);
       });
     });
   }


### PR DESCRIPTION
## Summary

Adds 5 new MCP tools for managing Uptime Kuma Docker host (docker daemon) configurations:

- `listDockerHosts` — list all configured docker daemons
- `addDockerHost` — register a new docker daemon (socket path or TCP URL)
- `updateDockerHost` — update an existing docker daemon (merges unspecified fields so a partial update doesn't wipe other columns)
- `deleteDockerHost` — remove a docker daemon
- `testDockerHost` — verify reachability before saving; resolves with `ok: false, msg` instead of rejecting so the caller gets the reason back

Wire-level implementation follows the existing Notification CRUD pattern: client-side `getDockerHostList()` / `addDockerHost(obj, id?)` / `deleteDockerHost(id)` / `testDockerHost(obj)` wrapping the matching socket events. A cache listener is installed on `dockerHostList` at login and cleared on disconnect.

### Why

Currently there's no way to configure UK's docker hosts from MCP — they can only be created through the UK Web UI. For multi-instance UK deployments (I run 4 redundant UKs), every host needs the same docker daemon configured, which means clicking through each UI manually. With these tools a single script can provision all of them.

## Files changed

- `src/types/docker-host.ts` *(new)* — `DockerHostSchema` (id/userID/name/dockerType/dockerDaemon, passthrough for any future fields)
- `src/types/index.ts` — export the new schema
- `src/uptime-kuma-client.ts` — cache, listener setup, 4 client methods
- `src/server.ts` — 5 MCP tools + instructions string updates

## Test plan

Tested end-to-end against a real Uptime Kuma instance (streamable-http transport):

- [x] `listDockerHosts` returns existing hosts
- [x] `testDockerHost` against an unreachable URL → `ok: false` with error message (`ECONNREFUSED`)
- [x] `testDockerHost` against a reachable URL → `ok: true` with container count
- [x] `addDockerHost` creates a new host and returns its new id
- [x] `updateDockerHost` with only `name` leaves `dockerType` / `dockerDaemon` untouched (merge correctness — UK's `addDockerHost` handler overwrites every column, so the tool fetches the existing record first)
- [x] `deleteDockerHost` removes the host; subsequent `listDockerHosts` confirms
- [x] Used the new tools to provision docker hosts on 4 independent UK instances — worked as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)