### PR TITLE
fix(types): allow null for heartbeat end_time (push monitors)

### DIFF
--- a/src/types/heartbeat.ts
+++ b/src/types/heartbeat.ts
@@ -16,7 +16,7 @@ export const HeartbeatSchema = z.object({
   duration: z.number().optional().describe('Seconds since last check'),
   down_count: z.number().optional().describe('Consecutive down count'),
   retries: z.number().optional().describe('Retry attempts'),
-  end_time: z.string().optional().describe('Check end time'),
+  end_time: z.string().nullable().optional().describe('Check end time'),
   monitorID: z.number().optional().describe('Monitor ID (camelCase)'),
   localDateTime: z.string().optional().describe('Local formatted time'),
   timezone: z.string().optional().describe('Server timezone'),


### PR DESCRIPTION
### Problem
For **push** monitors, Uptime Kuma returns `end_time: null` on the most recent (still-open) heartbeat. `HeartbeatSchema` declares:

```ts
end_time: z.string().optional()
```

`.optional()` permits the field to be *absent*, but **not `null`**. Because this schema is used as the tool **output** schema, the MCP SDK's output validation rejects those heartbeats, and `getHeartbeats` / `listHeartbeats` (which share `HeartbeatSchema`) return an error for **every push monitor**.

### Fix
```ts
end_time: z.string().nullable().optional()
```

### Verification
Reproduced and fixed against a real Uptime Kuma v2 instance with push monitors. Inspecting the full payload (`maxHeartbeats=100`) confirmed `end_time` is the **only** field returned as `null`; no sibling field needed loosening.
