### PR TITLE
fix(types): remove upper bound on monitor interval

### DIFF
--- a/src/types/monitor-base.ts
+++ b/src/types/monitor-base.ts
@@ -81,7 +81,7 @@ export const MonitorBaseSchema = z.object({
   weight: z.number().nullable().optional().describe('Display order weight'),
 
   // Timing
-  interval: z.number().min(20).max(86400).describe('Check interval in seconds (20-86400)'),
+  interval: z.number().min(20).describe('Check interval in seconds (min 20; Kuma allows >1 day, e.g. push/backup monitors)'),
   retryInterval: z.number().describe('Retry interval in seconds'),
   resendInterval: z.number().default(0).describe('Notification resend interval (0 = disabled)'),
   timeout: z.number().nullable().optional().describe('Request timeout in seconds'),


### PR DESCRIPTION
### Problem
`MonitorBaseSchema` caps the check interval at one day:

```ts
interval: z.number().min(20).max(86400)
```

Uptime Kuma legitimately allows larger intervals. Push monitors configured for a daily-or-longer push report intervals **above 86400** (e.g. `93600` for a daily backup grace window, `691200` for a weekly one). Since this schema feeds the tool **output** schema, the MCP SDK's output validation throws `too_big` on `monitors[*].interval`, so `listMonitors` / `getMonitor` return an error for exactly those monitors.

### Fix
```ts
interval: z.number().min(20)   // drop .max(86400); keep the lower bound
```

### Verification
Reproduced and fixed against a real Uptime Kuma v2 instance. Cross-checked the DB (`monitor` table): `interval` is the **only** capped field that is exceeded — `retryInterval` / `resendInterval` carry no upper bound in the schema and pass fine even at `691200`.
