### PR TITLE
fix: reverse heartbeatList on receipt so cache is newest-first

### DIFF
--- a/src/uptime-kuma-client.ts
+++ b/src/uptime-kuma-client.ts
@@ -370,7 +370,11 @@ export class UptimeKumaClient {
       // The heartbeatList event sends data per monitor, not all at once
       // Format: (monitorID, array of heartbeats, important flag)
       this.safeLog('debug', `Received heartbeatList for monitor ${monitorID}: ${heartbeatList.length} heartbeats`);
-      this.heartbeatListCache[monitorID.toString()] = heartbeatList;
+      // Uptime Kuma emits heartbeatList in ascending (oldest-first) order, but the
+      // cache is consumed newest-first: live 'heartbeat' events are unshift()ed to the
+      // front and reads use slice(0, maxHeartbeats). Reverse on receipt so the cache
+      // is consistently newest-first; otherwise reads return the oldest ~100 beats.
+      this.heartbeatListCache[monitorID.toString()] = heartbeatList.slice().reverse();
     });
 
     // Listen for individual heartbeat updates (real-time)


### PR DESCRIPTION
Fixes #56.

Uptime Kuma emits the connect-time `heartbeatList` event oldest-first, but the cache is consumed newest-first (live `heartbeat` events `unshift()` to the front; reads use `slice(0, maxHeartbeats)`). Storing the initial payload verbatim made `get_heartbeats`/`get_monitor_summary` return the oldest ~100 heartbeats — e.g. a six-week-old DOWN status-change reported as current.

**Change:** reverse the list on receipt (`heartbeatList.slice().reverse()`) so the cache is consistently newest-first. Comment added explaining the invariant.

**Testing:** full suite passes (89/89). Also verified live against Uptime Kuma 1.23.17: before, `maxHeartbeats: 5` returned beats from 2026-06-02; after, it returns the newest beats, matching `heartbeat` table order in kuma.db.

🤖 Generated with [Claude Code](https://claude.com/claude-code)