### PR TITLE
fix: add the monitor write fields that are silently dropped (#58, #60, #63, #65)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { McpError, ErrorCode, SetLevelRequestSchema, LoggingLevelSchema, type LoggingLevel } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
+import { randomBytes, randomInt } from 'node:crypto';
 import { UptimeKumaClient } from './uptime-kuma-client.js';
 import { HeartbeatSchema, MonitorBaseSchema, MonitorSummarySchema, SettingsSchema, NotificationSchema, MaintenanceSchema, StatusPageSchema, DockerHostSchema } from './types/index.js';
 import type { UptimeKumaConfig } from './types/index.js';
@@ -156,14 +157,17 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         type: z.string().optional().describe('Filter by monitor type(s). Comma-separated for multiple types. Use listMonitorTypes tool to see all available types.'),
         active: z.boolean().optional().describe('Filter by active status. true=only active monitors, false=only inactive monitors.'),
         maintenance: z.boolean().optional().describe('Filter by maintenance status. true=only monitors in maintenance, false=only monitors not in maintenance.'),
-        tags: z.string().optional().describe('Filter by tag name and optional value. Comma-separated for multiple tags. Format: "tagName" or "tagName=value". Monitor must have all specified tags. Case-insensitive. Examples: "production", "env=staging", "production,region=us-east"')
+        tags: z.string().optional().describe('Filter by tag name and optional value. Comma-separated for multiple tags. Format: "tagName" or "tagName=value". Monitor must have all specified tags. Case-insensitive. Examples: "production", "env=staging", "production,region=us-east"'),
+        // Issue #65: there was no way to list a group's members, so callers passing
+        // `parentId` got the entire monitor list back, which reads as a broken filter.
+        parentId: z.union([z.null(), z.coerce.number().int()]).optional().describe('Filter to the DIRECT children of this group monitor. Pass null for top-level monitors (those with no parent). Not recursive — use the group\'s own childrenIDs to walk deeper.')
       },
-      outputSchema: { 
+      outputSchema: {
         monitors: z.array(MonitorBaseSchema.passthrough()).describe('Array of monitor objects with common fields plus uptime/avgPing. May include type-specific fields when includeTypeSpecificFields is true.'),
         count: z.number()
       },
     },
-    async ({ includeTypeSpecificFields, keywords, type, active, maintenance, tags }) => {
+    async ({ includeTypeSpecificFields, keywords, type, active, maintenance, tags, parentId }) => {
       if (!isAuthenticated) {
         throw new McpError(
           ErrorCode.InternalError,
@@ -173,8 +177,8 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
 
       try {
         const monitorList = includeTypeSpecificFields
-          ? client.getMonitorList({ keywords, type, active, maintenance, tags, includeTypeSpecificFields: true })
-          : client.getMonitorList({ keywords, type, active, maintenance, tags, includeTypeSpecificFields: false });
+          ? client.getMonitorList({ keywords, type, active, maintenance, tags, parentId, includeTypeSpecificFields: true })
+          : client.getMonitorList({ keywords, type, active, maintenance, tags, parentId, includeTypeSpecificFields: false });
         const monitors = Object.values(monitorList);
         
         return {
@@ -537,14 +541,79 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
 
   // ─── Monitor write tools ──────────────────────────────────────────────────
 
+  // Uptime Kuma's editMonitor handler reads these fields under camelCase names on the wire
+  // (server/server.js: `bean.jsonPath = monitor.jsonPath`, `bean.pushToken = monitor.pushToken`,
+  // …) while the database columns are snake_case (json_path, push_token). The snake_case
+  // spellings are what the schema documentation, the database and issue #60 all use, so they
+  // are the ones callers reach for first. Accept both and normalise onto the name Kuma reads,
+  // rather than letting a reasonable guess silently do nothing.
+  const MONITOR_FIELD_ALIASES: Record<string, string> = {
+    json_path: 'jsonPath',
+    json_path_operator: 'jsonPathOperator',
+    expected_value: 'expectedValue',
+    push_token: 'pushToken',
+  };
+
+  const normaliseMonitorAliases = (fields: Record<string, unknown>): Record<string, unknown> => {
+    for (const [alias, canonical] of Object.entries(MONITOR_FIELD_ALIASES)) {
+      if (!(alias in fields)) continue;
+      if (canonical in fields && fields[canonical] !== fields[alias]) {
+        throw new Error(
+          `Conflicting values for ${canonical} (${JSON.stringify(fields[canonical])}) and its alias ${alias} (${JSON.stringify(fields[alias])}) — pass only '${canonical}'.`
+        );
+      }
+      fields[canonical] = fields[alias];
+      delete fields[alias];
+    }
+    return fields;
+  };
+
+  // Uptime Kuma generates push tokens in the browser (src/pages/EditMonitor.vue:
+  // genSecret(pushTokenLength) with pushTokenLength = 32). Match its length and alphabet.
+  const generatePushToken = (): string => {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    const bytes = randomBytes(32 * 2);
+    let token = '';
+    // Rejection sampling — modulo on a raw byte would bias the alphabet.
+    const max = 256 - (256 % chars.length);
+    for (let i = 0; token.length < 32 && i < bytes.length; i++) {
+      if (bytes[i] < max) token += chars[bytes[i] % chars.length];
+    }
+    while (token.length < 32) token += chars[randomInt(0, chars.length)];
+    return token;
+  };
+
+  // Uptime Kuma's own intent for an unset timeout is 0.8 x interval; only its unit handling is
+  // wrong. Storing the value at creation means the buggy runtime fallback never runs.
+  // push never polls and group has no request of its own, so both correctly keep 0.
+  const defaultTimeoutForInterval = (type: string, interval?: number): number | undefined => {
+    if (type === 'push' || type === 'group') return undefined;
+    const seconds = Math.round((interval ?? 60) * 0.8 * 10) / 10;
+    // Monitor.validate() rejects a ping timeout outside PING_GLOBAL_TIMEOUT_MIN/MAX (1..300).
+    if (type === 'ping') return Math.min(Math.max(Math.round(seconds), 1), 300);
+    return seconds;
+  };
+
   server.registerTool(
     'createMonitor',
     {
       title: 'Create Monitor',
-      description: 'Creates a new monitor in Uptime Kuma. Requires at minimum a name and type. Use listMonitorTypes to see supported types. For HTTP monitors include url; for TCP/port monitors include hostname and port.',
+      description: 'Creates a new monitor in Uptime Kuma. Requires at minimum a name and type. Use listMonitorTypes to see supported types. For HTTP monitors include url; for TCP/port monitors include hostname and port; for json-query include url, jsonPath, jsonPathOperator and expectedValue. A push monitor is given a generated push token (Uptime Kuma only generates one in its own web UI) and the resulting ping URL is returned. timeout defaults to 0.8 x interval seconds for polled types.',
       inputSchema: {
         name: z.string().describe('Display name for the monitor'),
         type: z.string().describe('Monitor type (e.g. http, port, ping, dns, push, keyword). Use listMonitorTypes for all options.'),
+        description: z.string().nullable().optional().describe('Free-text description shown on the monitor page'),
+        active: z.boolean().optional().describe('Whether the monitor starts checking immediately (default: true). Pass false to create it paused.'),
+        resendInterval: z.coerce.number().optional().describe('Resend notification every N checks while down (0 = disabled, the default)'),
+        timeout: z.coerce.number().nullable().optional().describe('Request timeout in SECONDS. Omit for 0.8 x interval. Avoid 0: Uptime Kuma\'s runtime fallback for a stored 0 computes interval * 1000 * 0.8 and then multiplies by 1000 again, yielding a ~13 hour timeout, so the monitor can never report DOWN against a host that accepts the connection and never answers.'),
+        jsonPath: z.string().optional().describe('JSONata expression for json-query monitors. Must resolve to a primitive.'),
+        json_path: z.string().optional().describe('Alias for jsonPath (the database column name). Prefer jsonPath.'),
+        jsonPathOperator: z.enum(['>', '>=', '<', '<=', '==', '!=', 'contains']).optional().describe('Comparison operator for json-query monitors. UP while value <operator> expectedValue.'),
+        json_path_operator: z.enum(['>', '>=', '<', '<=', '==', '!=', 'contains']).optional().describe('Alias for jsonPathOperator. Prefer jsonPathOperator.'),
+        expectedValue: z.coerce.string().optional().describe('Threshold the json-query result is compared against. Stored as a string.'),
+        expected_value: z.coerce.string().optional().describe('Alias for expectedValue. Prefer expectedValue.'),
+        pushToken: z.string().min(8).optional().describe('Push token for push monitors — the secret in the ping URL. Omit and one is generated and returned.'),
+        push_token: z.string().min(8).optional().describe('Alias for pushToken (the database column name). Prefer pushToken.'),
         url: z.string().optional().describe('URL to monitor (required for http/keyword/json-query types)'),
         hostname: z.string().optional().describe('Hostname to monitor (required for port/ping/dns types)'),
         port: z.coerce.number().optional().describe('Port number (required for port/tcp types)'),
@@ -576,6 +645,9 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         ok: z.boolean(),
         monitorID: z.number().optional(),
         msg: z.string().optional(),
+        pushToken: z.string().optional().describe('Push monitors only. The token, so the sender can be wired up without a second, wider read.'),
+        pushURL: z.string().optional().describe('Push monitors only. The URL the sender should GET.'),
+        timeout: z.number().optional().describe('The timeout in seconds actually stored, including the default applied when omitted.'),
       },
     },
     async (input) => {
@@ -594,14 +666,67 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
           defaults.dns_resolve_server = '1.1.1.1';
           defaults.dns_resolve_type = 'A';
         }
+
+        const requested = normaliseMonitorAliases({ ...input } as Record<string, unknown>);
+
+        // A json-query monitor without a query is accepted by Uptime Kuma and then fails
+        // every single check, which looks like a broken target rather than a broken config.
+        if (requested.type === 'json-query') {
+          const missing = ['jsonPath', 'jsonPathOperator', 'expectedValue'].filter(
+            (f) => requested[f] === undefined || requested[f] === ''
+          );
+          if (missing.length > 0) {
+            throw new Error(
+              `A json-query monitor needs ${missing.join(', ')}. Without them Uptime Kuma creates the monitor and then fails every check.`
+            );
+          }
+        }
+
+        // Uptime Kuma generates push tokens in the browser only (src/pages/EditMonitor.vue,
+        // genSecret(32)); the server has no such code path. Without this an API-created push
+        // monitor has an empty push_token, no ping URL, and can never report — while looking
+        // identical to one that is merely awaiting its first beat.
+        let generatedPushToken = false;
+        if (requested.type === 'push' && !requested.pushToken) {
+          requested.pushToken = generatePushToken();
+          generatedPushToken = true;
+        }
+
+        // Never leave timeout at 0 — see the schema description for why that is a ~13 hour
+        // timeout rather than a default.
+        if (requested.timeout === undefined || requested.timeout === null) {
+          const fallback = defaultTimeoutForInterval(
+            requested.type as string,
+            requested.interval as number | undefined
+          );
+          if (fallback !== undefined) requested.timeout = fallback;
+          else delete requested.timeout;
+        }
+
         const monitorData = {
           ...defaults,
-          ...input,
+          ...requested,
         };
         const response = await client.createMonitor(monitorData as Record<string, unknown>);
+
+        const structuredContent: Record<string, unknown> = {
+          ok: response.ok,
+          monitorID: response.monitorID,
+          msg: response.msg,
+        };
+        if (requested.timeout !== undefined) structuredContent.timeout = Number(requested.timeout);
+
+        let text = response.msg || `Monitor created with ID ${response.monitorID}`;
+        if (requested.type === 'push' && requested.pushToken) {
+          const base = config.url.replace(/\/+$/, '');
+          structuredContent.pushToken = requested.pushToken;
+          structuredContent.pushURL = `${base}/api/push/${requested.pushToken}?status=up&msg=OK&ping=`;
+          text += `\n\nPush monitor ${response.monitorID}: point the sender at (GET, not POST)\n  ${structuredContent.pushURL}\nThis URL contains a secret — treat it as a credential.${generatedPushToken ? ' The token was generated because Uptime Kuma only ever generates one in its own web UI.' : ''}`;
+        }
+
         return {
-          content: [{ type: 'text', text: response.msg || `Monitor created with ID ${response.monitorID}` }],
-          structuredContent: { ok: response.ok, monitorID: response.monitorID, msg: response.msg },
+          content: [{ type: 'text', text }],
+          structuredContent,
         };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -617,6 +742,23 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       description: 'Updates an existing monitor configuration. You must include the monitorID. Only the fields you provide will be changed (the server merges your changes with the existing config). Use getMonitor first to get the current config.',
       inputSchema: {
         monitorID: z.coerce.number().int().nonnegative().describe('The ID of the monitor to update'),
+        // `parent` was declared on createMonitor but not here, so an existing monitor could
+        // never be moved into or out of a group (issue #63). The merge below then folded the
+        // old value back in and Uptime Kuma replied "Saved." — a no-op reported as success.
+        parent: z.coerce.number().int().nullable().optional().describe('Parent group monitor ID — re-parents this monitor into that group. Pass null to move it to the top level.'),
+        parentID: z.coerce.number().int().nullable().optional().describe('Alias for parent. Prefer parent.'),
+        parent_id: z.coerce.number().int().nullable().optional().describe('Alias for parent. Prefer parent.'),
+        description: z.string().nullable().optional().describe('Free-text description shown on the monitor page'),
+        resendInterval: z.coerce.number().optional().describe('Resend notification every N checks while down (0 = disabled)'),
+        timeout: z.coerce.number().nullable().optional().describe('Request timeout in SECONDS. Avoid 0 — Uptime Kuma\'s runtime fallback for a stored 0 yields a ~13 hour timeout, so the monitor can never report DOWN against a black-holed endpoint.'),
+        jsonPath: z.string().optional().describe('JSONata expression for json-query monitors. Must resolve to a primitive.'),
+        json_path: z.string().optional().describe('Alias for jsonPath (the database column name). Prefer jsonPath.'),
+        jsonPathOperator: z.enum(['>', '>=', '<', '<=', '==', '!=', 'contains']).optional().describe('Comparison operator for json-query monitors.'),
+        json_path_operator: z.enum(['>', '>=', '<', '<=', '==', '!=', 'contains']).optional().describe('Alias for jsonPathOperator. Prefer jsonPathOperator.'),
+        expectedValue: z.coerce.string().optional().describe('Threshold the json-query result is compared against, stored as a string.'),
+        expected_value: z.coerce.string().optional().describe('Alias for expectedValue. Prefer expectedValue.'),
+        pushToken: z.string().min(8).optional().describe('Push token — the secret in the ping URL. Changing it invalidates the existing URL and any sender still using it stops beating.'),
+        push_token: z.string().min(8).optional().describe('Alias for pushToken (the database column name). Prefer pushToken.'),
         name: z.string().optional().describe('Display name'),
         url: z.string().optional().describe('URL to monitor'),
         hostname: z.string().optional().describe('Hostname'),
@@ -663,6 +805,19 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         }
         // Strip undefined values so existing config is preserved for omitted fields
         const defined = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined));
+        // Fold `parentID` / `parent_id` onto the single field Uptime Kuma's editMonitor
+        // handler reads (`bean.parent = monitor.parent`), along with the snake_case
+        // type-specific aliases, so a reasonable guess at a name cannot become a silent no-op.
+        for (const alias of ['parentID', 'parent_id']) {
+          if (alias in defined) {
+            if ('parent' in defined && defined.parent !== defined[alias]) {
+              throw new Error(`Conflicting values for parent (${defined.parent}) and ${alias} (${defined[alias]}) — pass only 'parent'.`);
+            }
+            defined.parent = defined[alias];
+            delete defined[alias];
+          }
+        }
+        normaliseMonitorAliases(defined);
         const merged = { ...existing, ...defined, id: monitorID };
         // Ensure retryInterval is valid — Kuma rejects values < 1 on edit even if
         // it stored 0 during creation (pre-existing monitors or older defaults)

--- a/src/uptime-kuma-client.ts
+++ b/src/uptime-kuma-client.ts
@@ -484,20 +484,34 @@ export class UptimeKumaClient {
     active?: boolean;
     maintenance?: boolean;
     tags?: string;
+    parentId?: number | null;
     includeTypeSpecificFields?: T;
   }): MonitorList<T> {
     const result: MonitorList<true> = {};
-    
+
     // Parse keywords into an array
     const keywordArray = filters?.keywords ? filters.keywords.trim().split(/\s+/) : [];
-    
+
     // Parse type filter from comma-separated string
     const typeFilter = filters?.type ? filters.type.split(',').map(t => t.trim()).filter(t => t.length > 0) : [];
-    
+
     // Parse tag filter from comma-separated string
     const tagFilter = filters?.tags ? filters.tags.split(',').map(t => t.trim()).filter(t => t.length > 0) : [];
-    
+
+    // `undefined` means "no parent filter"; `null` is a real value meaning "top level only",
+    // so the two must not be conflated into a truthiness check.
+    const filterByParent = filters?.parentId !== undefined;
+    const wantedParent = filters?.parentId === null ? null : Number(filters?.parentId);
+
     for (const [monitorID, monitor] of Object.entries(this.monitorListCache)) {
+      // Filter by parent group — direct children only, matching Uptime Kuma's `parent` column
+      if (filterByParent) {
+        const actualParent = monitor.parent === null || monitor.parent === undefined ? null : Number(monitor.parent);
+        if (actualParent !== wantedParent) {
+          continue;
+        }
+      }
+
     // Filter by keywords if provided using fuzzy matching
     if (keywordArray.length > 0) {
       const pathName = monitor.pathName || '';

--- a/test/integration/monitors.test.ts
+++ b/test/integration/monitors.test.ts
@@ -217,4 +217,188 @@ export const monitorTests: Array<{ name: string; fn: TestFn }> = [
       }
     },
   },
+  {
+    name: '#58: createMonitor and updateMonitor persist description',
+    fn: async ({ client }) => {
+      const createResult = await client.callTool({
+        name: 'createMonitor',
+        arguments: {
+          name: 'Integration Test - Issue 58',
+          type: 'http',
+          url: 'https://example.com',
+          interval: 120,
+          description: 'created with a description',
+          active: false,
+        },
+      }) as CallToolResult;
+      const monitorID = extractID(createResult, 'createMonitor', 'monitorID');
+
+      try {
+        const created = JSON.parse(extractText(
+          await client.callTool({ name: 'getMonitor', arguments: { monitorID } }) as CallToolResult,
+          'getMonitor'
+        ));
+        if (created.description !== 'created with a description') {
+          throw new Error(`description not persisted on create: got ${JSON.stringify(created.description)}`);
+        }
+        // `active` was also absent from createMonitor's schema, so a request to create a
+        // paused monitor was silently ignored and it started checking immediately.
+        if (created.active !== false) throw new Error('active:false not honoured on create');
+
+        await client.callTool({ name: 'updateMonitor', arguments: { monitorID, description: 'edited' } });
+        const edited = JSON.parse(extractText(
+          await client.callTool({ name: 'getMonitor', arguments: { monitorID } }) as CallToolResult,
+          'getMonitor'
+        ));
+        if (edited.description !== 'edited') {
+          throw new Error(`description not persisted on update: got ${JSON.stringify(edited.description)}`);
+        }
+        console.log('  ✓ #58: description persists on create and update; active:false honoured');
+      } finally {
+        await client.callTool({ name: 'deleteMonitor', arguments: { monitorID } });
+      }
+    },
+  },
+  {
+    name: '#60: json-query monitors are fully configurable',
+    fn: async ({ client }) => {
+      const createResult = await client.callTool({
+        name: 'createMonitor',
+        arguments: {
+          name: 'Integration Test - Issue 60 json-query',
+          type: 'json-query',
+          url: 'https://example.com',
+          interval: 300,
+          active: false,
+          jsonPath: '$.freeSpace',
+          jsonPathOperator: '>',
+          expectedValue: 161061273600,
+        },
+      }) as CallToolResult;
+      const monitorID = extractID(createResult, 'createMonitor', 'monitorID');
+
+      try {
+        const m = JSON.parse(extractText(
+          await client.callTool({ name: 'getMonitor', arguments: { monitorID, includeTypeSpecificFields: true } }) as CallToolResult,
+          'getMonitor'
+        ));
+        if (m.jsonPath !== '$.freeSpace') throw new Error(`jsonPath not persisted: ${JSON.stringify(m.jsonPath)}`);
+        if (m.jsonPathOperator !== '>') throw new Error(`jsonPathOperator not persisted: ${JSON.stringify(m.jsonPathOperator)}`);
+        if (String(m.expectedValue) !== '161061273600') throw new Error(`expectedValue not persisted: ${JSON.stringify(m.expectedValue)}`);
+
+        // snake_case aliases — the database column names, and the spelling used in #60
+        await client.callTool({
+          name: 'updateMonitor',
+          arguments: { monitorID, json_path: '$.total', json_path_operator: '<', expected_value: '42' },
+        });
+        const m2 = JSON.parse(extractText(
+          await client.callTool({ name: 'getMonitor', arguments: { monitorID, includeTypeSpecificFields: true } }) as CallToolResult,
+          'getMonitor'
+        ));
+        if (m2.jsonPath !== '$.total' || m2.jsonPathOperator !== '<' || String(m2.expectedValue) !== '42') {
+          throw new Error('snake_case aliases were not normalised onto the camelCase fields');
+        }
+        console.log('  ✓ #60: json-query triple persists, snake_case aliases normalised');
+      } finally {
+        await client.callTool({ name: 'deleteMonitor', arguments: { monitorID } });
+      }
+    },
+  },
+  {
+    name: '#60: push monitors are created with a usable token and ping URL',
+    fn: async ({ client }) => {
+      const createResult = await client.callTool({
+        name: 'createMonitor',
+        arguments: { name: 'Integration Test - Issue 60 push', type: 'push', interval: 3600 },
+      }) as CallToolResult;
+      const monitorID = extractID(createResult, 'createMonitor', 'monitorID');
+
+      try {
+        const sc = (createResult as any).structuredContent;
+        if (!sc?.pushToken || String(sc.pushToken).length !== 32) {
+          throw new Error(`expected a 32-character generated push token, got ${JSON.stringify(sc?.pushToken)}`);
+        }
+        if (!sc?.pushURL || !String(sc.pushURL).includes('/api/push/')) {
+          throw new Error(`expected a ping URL, got ${JSON.stringify(sc?.pushURL)}`);
+        }
+        const stored = JSON.parse(extractText(
+          await client.callTool({ name: 'getMonitor', arguments: { monitorID, includeTypeSpecificFields: true } }) as CallToolResult,
+          'getMonitor'
+        ));
+        if (stored.pushToken !== sc.pushToken) throw new Error('stored push token does not match the returned one');
+
+        // The whole point: the returned URL must actually be able to record a beat.
+        const res = await fetch(`${String(sc.pushURL)}&msg=integration-test`);
+        if (res.status !== 200) throw new Error(`push URL returned HTTP ${res.status}`);
+        console.log('  ✓ #60: push token generated, stored, and the ping URL accepts a heartbeat');
+      } finally {
+        await client.callTool({ name: 'deleteMonitor', arguments: { monitorID } });
+      }
+    },
+  },
+  {
+    name: '#63/#65: updateMonitor re-parents, and listMonitors filters by parent',
+    fn: async ({ client }) => {
+      const groupID = extractID(await client.callTool({
+        name: 'createMonitor',
+        arguments: { name: 'Integration Test - Issue 63 group', type: 'group', interval: 300, active: false },
+      }) as CallToolResult, 'createMonitor', 'monitorID');
+      const monitorID = extractID(await client.callTool({
+        name: 'createMonitor',
+        arguments: { name: 'Integration Test - Issue 63 child', type: 'http', url: 'https://example.com', interval: 300, active: false },
+      }) as CallToolResult, 'createMonitor', 'monitorID');
+
+      try {
+        await client.callTool({ name: 'updateMonitor', arguments: { monitorID, parent: groupID } });
+        const moved = JSON.parse(extractText(
+          await client.callTool({ name: 'getMonitor', arguments: { monitorID } }) as CallToolResult,
+          'getMonitor'
+        ));
+        if (Number(moved.parent) !== groupID) {
+          throw new Error(`re-parent did not persist: parent is ${JSON.stringify(moved.parent)}, expected ${groupID}`);
+        }
+
+        const listed = JSON.parse(extractText(
+          await client.callTool({ name: 'listMonitors', arguments: { parentId: groupID } }) as CallToolResult,
+          'listMonitors'
+        ));
+        if (!Array.isArray(listed) || listed.length !== 1 || Number(listed[0].id) !== monitorID) {
+          throw new Error(`parentId filter returned ${Array.isArray(listed) ? listed.length : 'non-array'} monitors, expected exactly the one child`);
+        }
+
+        await client.callTool({ name: 'updateMonitor', arguments: { monitorID, parent: null } });
+        const back = JSON.parse(extractText(
+          await client.callTool({ name: 'getMonitor', arguments: { monitorID } }) as CallToolResult,
+          'getMonitor'
+        ));
+        if (back.parent !== null) throw new Error('re-parent to top level did not persist');
+        console.log('  ✓ #63/#65: re-parent works both ways; parentId returns direct children');
+      } finally {
+        await client.callTool({ name: 'deleteMonitor', arguments: { monitorID } });
+        await client.callTool({ name: 'deleteMonitor', arguments: { monitorID: groupID } });
+      }
+    },
+  },
+  {
+    name: 'timeout defaults to 0.8 x interval instead of being stored as 0',
+    fn: async ({ client }) => {
+      const monitorID = extractID(await client.callTool({
+        name: 'createMonitor',
+        arguments: { name: 'Integration Test - timeout default', type: 'http', url: 'https://example.com', interval: 300, active: false },
+      }) as CallToolResult, 'createMonitor', 'monitorID');
+
+      try {
+        const m = JSON.parse(extractText(
+          await client.callTool({ name: 'getMonitor', arguments: { monitorID } }) as CallToolResult,
+          'getMonitor'
+        ));
+        if (Number(m.timeout) !== 240) {
+          throw new Error(`expected timeout 240 (0.8 x 300), got ${JSON.stringify(m.timeout)}`);
+        }
+        console.log('  ✓ timeout defaulted to 240s rather than 0');
+      } finally {
+        await client.callTool({ name: 'deleteMonitor', arguments: { monitorID } });
+      }
+    },
+  },
 ];

--- a/test/unit/monitor-parent-filter.test.ts
+++ b/test/unit/monitor-parent-filter.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { UptimeKumaClient } from '../../src/uptime-kuma-client.js';
+import { injectMonitorListCache } from './helpers.js';
+
+/**
+ * getMonitorList({ parentId }) — issue #65.
+ *
+ * There was no parent filter at all, so a caller asking for one group's members got every
+ * monitor back. The distinction that matters here is `undefined` (no filter) versus `null`
+ * (top-level only): conflating them via a truthiness check silently breaks one of the two.
+ */
+describe('UptimeKumaClient - getMonitorList parentId filter', () => {
+  let client: UptimeKumaClient;
+
+  beforeEach(() => {
+    client = new UptimeKumaClient('http://localhost:3001');
+    injectMonitorListCache(client, {
+      '1': { id: 1, name: 'Group A', type: 'group', parent: null, pathName: 'Group A', active: true },
+      '2': { id: 2, name: 'Child A1', type: 'http', parent: 1, pathName: 'Group A / Child A1', active: true },
+      '3': { id: 3, name: 'Child A2', type: 'http', parent: 1, pathName: 'Group A / Child A2', active: true },
+      '4': { id: 4, name: 'Group B', type: 'group', parent: null, pathName: 'Group B', active: true },
+      '5': { id: 5, name: 'Child B1', type: 'http', parent: 4, pathName: 'Group B / Child B1', active: true },
+      '6': { id: 6, name: 'Grandchild', type: 'http', parent: 5, pathName: 'Group B / Child B1 / Grandchild', active: true },
+    });
+  });
+
+  it('returns only the direct children of the given group', () => {
+    const result = client.getMonitorList({ parentId: 1 });
+    expect(Object.keys(result).sort()).toEqual(['2', '3']);
+  });
+
+  it('is not recursive — a grandchild is not returned', () => {
+    const result = client.getMonitorList({ parentId: 4 });
+    expect(Object.keys(result)).toEqual(['5']);
+    expect(result['6']).toBeUndefined();
+  });
+
+  it('parentId null returns only top-level monitors', () => {
+    const result = client.getMonitorList({ parentId: null });
+    expect(Object.keys(result).sort()).toEqual(['1', '4']);
+  });
+
+  it('omitting parentId returns everything (undefined is not the same as null)', () => {
+    expect(Object.keys(client.getMonitorList({})).length).toBe(6);
+    expect(Object.keys(client.getMonitorList()).length).toBe(6);
+  });
+
+  it('parentId 0 is treated as a real id, not as "no filter"', () => {
+    // Guards against a truthiness check: `if (filters.parentId)` would skip filtering here.
+    const result = client.getMonitorList({ parentId: 0 });
+    expect(Object.keys(result).length).toBe(0);
+  });
+
+  it('combines with other filters rather than replacing them', () => {
+    const result = client.getMonitorList({ parentId: 1, type: 'http' });
+    expect(Object.keys(result).sort()).toEqual(['2', '3']);
+    expect(Object.keys(client.getMonitorList({ parentId: 1, type: 'group' })).length).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #58, fixes #60, fixes #63, and the `listMonitors` half of #65.

## The shared cause

Several fields are missing from `createMonitor` / `updateMonitor`'s `inputSchema`. The MCP SDK validates arguments with a plain `z.object(...)`, which **strips unknown keys rather than erroring**. `updateMonitor` then merges what survived over the monitor's existing config:

```js
const merged = { ...existing, ...defined, id: monitorID };
```

so the stripped field is refilled with its **old** value, Uptime Kuma applies a legal edit, and answers `{"ok":true,"msg":"Saved."}`. That response is true — it did save; it just saved the old value — and nothing distinguishes it from a complete write. Every issue above is one instance of this.

## What this adds

To both write tools: `description` (#58), `jsonPath` / `jsonPathOperator` / `expectedValue` and `pushToken` (#60), and `timeout`.

To `updateMonitor`: **`parent`** (#63). `createMonitor` already declared it, so an existing monitor could never be moved into or out of a group — as @buliwyf42 notes on #58, that means an existing installation can't be reorganised into groups programmatically at all.

To `createMonitor`: **`active`** and `resendInterval`. `active: false` was silently ignored, so "create this paused" created a monitor that started polling immediately. This one wasn't in any issue — it surfaced only once unknown keys stopped being silent.

To `listMonitors`: **`parentId`** (#65). There was no parent filter at all, so passing one returned every monitor, which reads as a broken filter rather than an absent one. Direct children only; `null` means top-level.

## Wire names are camelCase, columns are snake_case

Worth flagging because it isn't obvious and it decides what callers should pass. Kuma's `editMonitor` handler reads:

```js
bean.jsonPath        = monitor.jsonPath;
bean.jsonPathOperator = monitor.jsonPathOperator;
bean.expectedValue   = monitor.expectedValue;
bean.pushToken       = monitor.pushToken;
```

while the database columns are `json_path`, `json_path_operator`, `expected_value`, `push_token` — and the snake_case spellings are the ones people reach for first, because they're what the database shows and what #60 itself uses. Both are accepted and normalised onto the name Kuma actually reads. Passing a field **and** its alias with different values is an error rather than a coin flip.

## Two behaviour changes, both separable

Happy to drop either if you'd rather this PR stayed purely additive — say the word and I'll strip them out.

**1. A push monitor with no token gets a generated one, and the ping URL is returned.** Kuma generates push tokens in the browser only (`src/pages/EditMonitor.vue`, `genSecret(pushTokenLength)` with `pushTokenLength = 32`); the server has no such code path. So `createMonitor {type: "push"}` currently succeeds with an **empty** `push_token` — no URL to ping, and a monitor that can never report while looking identical to one merely awaiting its first beat. This is wider than #60 describes: it isn't "you can't choose the token", it's "there is no token". Same length and alphabet as Kuma's own generator, crypto RNG with rejection sampling.

The URL is returned at creation because otherwise the only way to learn it is `getMonitor {includeTypeSpecificFields: true}`, which also hands back `basic_auth_pass`, `bearer_token` and `headers` — a wider disclosure than the one field you need. A caller-supplied token is used verbatim and is **not** echoed back.

**2. `timeout` defaults to `0.8 × interval` seconds when omitted.** Adding the field alone would still leave every monitor created without it at `0`, and `0` is not "unset". `server/model/monitor.js`:

```js
// line 462 — "Runtime patch timeout if it is 0"
if (!this.timeout || this.timeout <= 0) {
    this.timeout = this.interval * 1000 * 0.8;   // 60 * 1000 * 0.8 = 48000
}
// line 558 — then multiplied by 1000 again
timeout: this.timeout * 1000,                    // 48,000,000 ms ≈ 13.3 hours
```

`timeout` is in seconds everywhere else, so that's a unit bug in Uptime Kuma itself (reported separately upstream) — but the consequence lands here: an MCP-created monitor **cannot report DOWN against a black-holed endpoint**. It hangs, the beat never completes, and the tile keeps its last-known state. A *refused* connection still fails fast, so it looks fine in every test you'd naturally run; you only see it against a host that accepts the TCP connection and then never answers. Storing the value at creation means the buggy fallback never runs. `push` and `group` correctly keep `0`; `ping` is clamped to 1..300s, which `Monitor.validate()` enforces.

Also: a `json-query` monitor created without `jsonPath` / `jsonPathOperator` / `expectedValue` is now refused, instead of being created and then failing every single check.

## Testing

- **6 new unit tests** for the `parentId` filter — including that `undefined` (no filter) and `null` (top level) aren't conflated, that `parentId: 0` is treated as a real id rather than "no filter", and that it isn't recursive.
- **5 new integration tests**, one per issue, run against a live Uptime Kuma **2.4.0**. The push test asserts the returned URL actually records a heartbeat, not just that a token exists.
- Full suite green: `95 unit`, `12/12 monitors integration`.

## One unrelated thing I hit

`test/integration/helpers.ts` loads `.env.test` with `dotenv`, which does **not** override variables already in the environment. On a machine that also has `UPTIME_KUMA_URL` / `UPTIME_KUMA_JWT_TOKEN` set for a real instance, the integration suite silently picks up the ambient values instead of the test ones — and that suite creates and deletes monitors. I hit it as an `authInvalidToken` (ambient token, test URL), but the same mechanism could point it at a production instance. `override: true` would fix it. Not touched here since it's out of scope for this PR — happy to send it separately if you'd like.
