### PR TITLE
fix: reject unknown tool arguments instead of silently stripping them (#65)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -49,6 +49,85 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
     }
   );
 
+  // Reject unknown keys instead of silently stripping them.
+  //
+  // registerTool is normally handed a raw Zod *shape*, which the SDK turns into a plain
+  // z.object(shape). A plain object schema DROPS keys it doesn't know about rather than
+  // erroring, and the write handlers then merge what survived over the monitor's existing
+  // config — so a field this server doesn't declare is refilled with its old value and
+  // Uptime Kuma answers {"ok":true,"msg":"Saved."}. A partial write reported as a complete
+  // one. That is the shared mechanism behind #58, #60, #63 and #65; each was reported
+  // separately because there is nothing in the response to connect them.
+  //
+  // getZodSchemaObject / normalizeObjectSchema both accept an already-built Zod object and
+  // pass it through untouched, so upgrading every shape to .strict() here converts the whole
+  // class from silent data loss into a loud error that names the offending key. It also puts
+  // additionalProperties: false into the advertised JSON Schema, so callers are told up front
+  // rather than discovering it from a write that didn't happen.
+  //
+  // Done by wrapping the method once rather than editing ~31 schemas by hand: one seam, no
+  // chance of missing one, and it covers any tool added later.
+  const registerToolUnstrict = server.registerTool.bind(server);
+  (server as unknown as { registerTool: typeof server.registerTool }).registerTool = ((
+    name: string,
+    config: Record<string, unknown>,
+    cb: unknown
+  ) => {
+    const shape = config?.inputSchema as Record<string, unknown> | undefined;
+    // Only upgrade raw shapes; anything already a Zod schema is left alone.
+    if (shape && typeof shape === 'object' && !('_def' in shape) && !('_zod' in shape)) {
+      config = { ...config, inputSchema: strictInputSchema(name, shape as z.ZodRawShape) };
+    }
+    return (registerToolUnstrict as unknown as (n: string, c: unknown, f: unknown) => unknown)(name, config, cb);
+  }) as typeof server.registerTool;
+
+  /**
+   * Builds the strict schema, and makes an unknown key the FIRST thing the caller reads.
+   *
+   * Zod appends `unrecognized_keys` after the per-field issues, which leaves the second half
+   * of #65 intact: `getMonitor {monitorId: 1}` reports BOTH "unknown key monitorId" and
+   * "monitorID: expected number, received nan" — because z.coerce.number() coerces the
+   * now-missing monitorID to NaN — and the NaN line comes first. That line is the misleading
+   * one: it points at a field the caller never got wrong. Reordering turns a message that
+   * sends you hunting for a type bug into one that says "you misspelled this key".
+   */
+  function strictInputSchema(toolName: string, shape: z.ZodRawShape) {
+    const schema = z.object(shape).strict();
+    const accepted = Object.keys(shape);
+
+    const reorder = (result: z.SafeParseReturnType<unknown, unknown>) => {
+      if (result.success) return result;
+      const issues = result.error?.issues;
+      if (!Array.isArray(issues)) return result;
+      const unknown = issues.filter((i) => i.code === 'unrecognized_keys');
+      if (unknown.length === 0) return result;
+
+      const named = unknown.flatMap((i) => (i as z.ZodIssue & { keys?: string[] }).keys ?? []);
+      const lead = {
+        code: 'unrecognized_keys',
+        keys: named,
+        path: [],
+        message:
+          `Unknown field(s) for ${toolName}: ${named.map((k) => `'${k}'`).join(', ')}. ` +
+          'Field names are case-sensitive — check spelling and casing first (monitorID, not monitorId). ' +
+          `Accepted fields: ${accepted.join(', ')}. ` +
+          'Any other issue reported below may be a knock-on effect of this one: a required field ' +
+          'that looks absent is usually the misspelled key.',
+      } as unknown as z.ZodIssue;
+      const rest = issues.filter((i) => i.code !== 'unrecognized_keys');
+      return { success: false as const, error: new z.ZodError([lead, ...rest]) };
+    };
+
+    const safeParse = schema.safeParse.bind(schema);
+    const safeParseAsync = schema.safeParseAsync.bind(schema);
+    (schema as unknown as { safeParse: unknown }).safeParse = (data: unknown, params?: unknown) =>
+      reorder(safeParse(data, params as never));
+    (schema as unknown as { safeParseAsync: unknown }).safeParseAsync = async (data: unknown, params?: unknown) =>
+      reorder(await safeParseAsync(data, params as never));
+
+    return schema;
+  }
+
   // Handle logging level changes via the underlying server
   server.server.setRequestHandler(SetLevelRequestSchema, async (request) => {
     const level = request.params?.level as LoggingLevel | undefined;

--- a/test/integration/run-all.ts
+++ b/test/integration/run-all.ts
@@ -13,6 +13,7 @@ import { maintenanceTests } from './maintenance.test.js';
 import { notificationTests } from './notifications.test.js';
 import { dockerHostTests } from './docker-hosts.test.js';
 import { statusPageTests } from './status-pages.test.js';
+import { strictSchemaTests } from './strict-schema.test.js';
 
 /**
  * Unified integration test runner.
@@ -35,6 +36,7 @@ const ALL_SUITES: Record<string, { name: string; tests: Array<{ name: string; fn
   notifications: { name: 'Notifications', tests: notificationTests },
   'docker-hosts': { name: 'Docker Hosts', tests: dockerHostTests },
   'status-pages': { name: 'Status Pages', tests: statusPageTests },
+  'strict-schema': { name: 'Strict Input Schemas', tests: strictSchemaTests },
 };
 
 async function main() {

--- a/test/integration/strict-schema.test.ts
+++ b/test/integration/strict-schema.test.ts
@@ -1,0 +1,121 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { TestFn, extractText, extractID } from './helpers.js';
+
+/**
+ * Integration tests for strict input schemas.
+ *
+ * Issue coverage:
+ * - #65: a misspelled `monitorId` reported "expected number, received nan" for `monitorID`,
+ *        blaming a field the caller never got wrong.
+ * - The shared mechanism behind #58 / #60 / #63: an undeclared field was stripped before the
+ *   handler ran, refilled from the existing config, and the call still reported success.
+ */
+
+/** Runs a tool and returns the error message, or throws if the call unexpectedly succeeded. */
+async function expectToolError(client: any, name: string, args: Record<string, unknown>): Promise<string> {
+  try {
+    const result = await client.callTool({ name, arguments: args }) as CallToolResult;
+    if (!result.isError) {
+      throw new Error(`${name} accepted arguments it should have rejected: ${JSON.stringify(args)}`);
+    }
+    const textContent = (result.content as any[])?.find((c: any) => c.type === 'text');
+    return String(textContent?.text ?? '');
+  } catch (err) {
+    // The SDK surfaces validation failures as a thrown McpError rather than isError.
+    const message = err instanceof Error ? err.message : String(err);
+    if (/accepted arguments it should have rejected/.test(message)) throw err;
+    return message;
+  }
+}
+
+export const strictSchemaTests: Array<{ name: string; fn: TestFn }> = [
+  {
+    name: '#65: a misspelled key is named, instead of being stripped and blamed on another field',
+    fn: async ({ client }) => {
+      const message = await expectToolError(client, 'getMonitor', { monitorId: 1 });
+
+      if (!message.includes('monitorId')) {
+        throw new Error(`error does not name the offending key: ${message}`);
+      }
+      if (!/Accepted fields/.test(message)) {
+        throw new Error(`error does not list the accepted fields: ${message}`);
+      }
+      // The NaN complaint may still appear (Zod appends unrecognized_keys last), but it must
+      // not be the first thing read — that is the misleading half of #65.
+      const nanAt = message.toLowerCase().indexOf('nan');
+      if (nanAt !== -1 && message.indexOf('monitorId') > nanAt) {
+        throw new Error('the NaN complaint still precedes the unknown-key error');
+      }
+      console.log('  ✓ #65: unknown key named first, accepted fields listed');
+    },
+  },
+  {
+    name: 'an undeclared write field is rejected rather than silently dropped',
+    fn: async ({ client }) => {
+      const monitorID = extractID(await client.callTool({
+        name: 'createMonitor',
+        arguments: {
+          name: 'Integration Test - strict schema',
+          type: 'http',
+          url: 'https://example.com',
+          interval: 300,
+        },
+      }) as CallToolResult, 'createMonitor', 'monitorID');
+
+      try {
+        // Previously this returned {"ok":true,"msg":"Saved."} having written nothing.
+        const message = await expectToolError(client, 'updateMonitor', {
+          monitorID,
+          thisFieldDoesNotExist: 'value',
+        });
+        if (!message.includes('thisFieldDoesNotExist')) {
+          throw new Error(`error does not name the unknown field: ${message}`);
+        }
+        console.log('  ✓ undeclared field rejected and named');
+      } finally {
+        await client.callTool({ name: 'deleteMonitor', arguments: { monitorID } });
+      }
+    },
+  },
+  {
+    name: 'declared fields still work — strictness does not break valid calls',
+    fn: async ({ client }) => {
+      const monitorID = extractID(await client.callTool({
+        name: 'createMonitor',
+        arguments: {
+          name: 'Integration Test - strict schema valid',
+          type: 'http',
+          url: 'https://example.com',
+          interval: 300,
+          retryInterval: 60,
+          maxretries: 2,
+        },
+      }) as CallToolResult, 'createMonitor', 'monitorID');
+
+      try {
+        await client.callTool({ name: 'updateMonitor', arguments: { monitorID, name: 'renamed' } });
+        const monitor = JSON.parse(extractText(
+          await client.callTool({ name: 'getMonitor', arguments: { monitorID } }) as CallToolResult,
+          'getMonitor'
+        ));
+        if (monitor.name !== 'renamed') throw new Error('valid update did not apply');
+        console.log('  ✓ valid calls unaffected');
+      } finally {
+        await client.callTool({ name: 'deleteMonitor', arguments: { monitorID } });
+      }
+    },
+  },
+  {
+    name: 'tools/list advertises additionalProperties:false',
+    fn: async ({ client }) => {
+      const { tools } = await client.listTools();
+      const loose = tools
+        .filter((t: any) => t.inputSchema?.additionalProperties !== false)
+        .map((t: any) => t.name);
+      if (loose.length > 0) {
+        throw new Error(`these tools still advertise an open schema: ${loose.join(', ')}`);
+      }
+      console.log(`  ✓ all ${tools.length} tools advertise additionalProperties:false`);
+    },
+  },
+];


### PR DESCRIPTION
Fixes the second half of #65, and the shared cause behind #58, #60 and #63.

Companion to #69, but **independent** — either can merge first. #69 adds the specific fields that are missing; this stops the next missing field from failing silently. If you only want one, take #69: it fixes what people have actually hit. This one is the reason they hit it.

## The mechanism

`registerTool` is handed a raw Zod *shape*, which the SDK turns into a plain `z.object(shape)`. A plain object schema **strips** keys it doesn't know about rather than erroring. The monitor write handlers then merge what survived over the existing config:

```js
const merged = { ...existing, ...defined, id: monitorID };
```

So an undeclared field is refilled with its **old** value, Uptime Kuma applies a perfectly legal edit, and replies `{"ok":true,"msg":"Saved."}`. That reply is true — it did save. It saved the old value. Nothing in the response distinguishes it from a complete write.

#58, #60, #63 and #65 are all this. They were filed as four separate bugs because from the outside there is no way to tell they're one, and each reporter found a different field. Adding fields one at a time fixes the instances noticed so far; there's no reason to think the list is complete.

Evidence for that: while testing #69 I found `active` was missing from `createMonitor` too, so `active: false` was silently ignored and "create this monitor paused" created one that started polling immediately. Nobody had reported it. It surfaced within seconds of unknown keys becoming loud.

## The change

`server.registerTool` is wrapped once so every tool's shape is built with `.strict()`. `getZodSchemaObject` / `normalizeObjectSchema` both accept an already-built Zod object and pass it through untouched, so this needs no per-tool edits — one seam, all 31 tools, and any tool added later is covered automatically.

Two consequences beyond the error:

- **`additionalProperties: false` now appears in the advertised JSON Schema**, so a caller is told the truth up front instead of discovering it from a write that didn't happen.
- **The error names the key.** That alone fixes the "unknown field" half of #65.

## The misleading-error half of #65

`.strict()` alone wasn't quite enough. Zod appends `unrecognized_keys` *after* the per-field issues, so `getMonitor {monitorId: 1}` reported both:

```
monitorID: expected number, received nan     ← first
unknown key 'monitorId'                      ← second
```

The NaN line is the misleading one — it blames a field the caller never got wrong, because `z.coerce.number()` coerced the now-missing `monitorID` to `NaN`. That's precisely what #65 describes, and leaving it first would have left the report half-answered. The unknown-key issue is reordered to the front, and its message names the keys, lists what the tool accepts, and warns that anything below may be a knock-on effect:

```
Unknown field(s) for getMonitor: 'monitorId'. Field names are case-sensitive — check
spelling and casing first (monitorID, not monitorId). Accepted fields: monitorID,
includeTypeSpecificFields. Any other issue reported below may be a knock-on effect of
this one: a required field that looks absent is usually the misspelled key.
```

## Is this breaking?

Technically yes: a caller passing a harmless extra now gets an error where it previously got silence. Three things make me think it's the right trade:

1. **The full integration suite passes unchanged — 28/28.** Nothing in the existing tests passes an argument that strictness rejects, across all 31 tools.
2. The silent behaviour is what generated four separate bug reports. A loud, self-describing error costs one retry; the silent version cost each of those reporters a debugging session, and in my case a stale monitor I didn't know was stale.
3. It's the difference between "this MCP doesn't support X" and "you spelled X wrong" — which an agent driving these tools cannot currently tell apart.

If you'd rather have it opt-in, I'm happy to put it behind an env var (`MCP_STRICT_ARGS=1`) or invert it to a warning logged via `sendLoggingMessage`. Say which and I'll push it.

## Testing

- 4 new integration tests: the #65 repro (key named, ordering correct, accepted fields listed), an undeclared write field being rejected rather than dropped, valid calls still working, and a check that **every** tool advertises `additionalProperties: false`.
- Existing suites: 89 unit, 28/28 integration against a live Uptime Kuma 2.4.0.
