### PR TITLE
fix: recover from a lost Uptime Kuma session instead of wedging (#64)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,18 @@ function validateEnvironment(): UptimeKumaConfig {
     process.exit(1);
   }
 
+  // Fail loudly and early on a credential that cannot possibly work. Uptime Kuma rejects a
+  // non-JWT with the opaque message "authInvalidToken", which is indistinguishable from an
+  // expired credential — so say what is actually wrong. Reports the SHAPE only, never the value.
+  if (jwtToken && String(jwtToken).split('.').length !== 3) {
+    console.error(
+      'WARNING: UPTIME_KUMA_JWT_TOKEN is not a JWT '
+      + `(${String(jwtToken).split('.').length} dot-separated segment(s), length ${String(jwtToken).length}; expected 3). `
+      + 'Uptime Kuma will reject every request with "authInvalidToken". '
+      + `Regenerate with: mcp-uptime-kuma-get-jwt ${url} <username> <password>`
+    );
+  }
+
   return { url, username, password, token, jwtToken };
 }
 
@@ -77,9 +89,19 @@ async function runStdio(config: UptimeKumaConfig) {
     const transport = new StdioServerTransport();
     
     await server.connect(transport);
-    
-    // Now authenticate after transport is connected so we can log properly
-    await authenticateClient();
+
+    // Now authenticate after transport is connected so we can log properly.
+    //
+    // A startup auth failure must NOT kill the process. Uptime Kuma being briefly
+    // unreachable — a container restart, a host still booting, a stopped service — would
+    // otherwise exit here and the MCP client would report the server as permanently broken.
+    // Leave the server up and let each tool call authenticate lazily, so it recovers on its
+    // own once Uptime Kuma is back.
+    try {
+      await authenticateClient();
+    } catch (error) {
+      process.stderr.write(`Initial authentication failed, will retry on demand: ${error}\n`);
+    }
   } catch (error) {
     process.stderr.write(`Fatal error in stdio transport: ${error}\n`);
     process.exit(1);

--- a/src/server.ts
+++ b/src/server.ts
@@ -68,32 +68,82 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
   
   const client = new UptimeKumaClient(config.url, server, shouldLog);
   let isAuthenticated = false;
-  
-  // Function to authenticate the client (to be called after transport is connected)
-  const authenticateClient = async () => {
-    try {
-      await client.connect();
-      await client.login(config.username, config.password, config.token, config.jwtToken);
+  let authInFlight: Promise<void> | null = null;
 
-      // Logging in anonymously gives no indication that authentication failed.
-      // So instead, we issue a getSettings call after login, to prove the connection is working.
-      await client.getSettings();
-      isAuthenticated = true;
-      
-      await server.sendLoggingMessage({
-        level: 'info',
-        data: 'Successfully authenticated with Uptime Kuma'
-      });
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      await server.sendLoggingMessage({
-        level: 'error',
-        data: `Failed to authenticate with Uptime Kuma: ${errorMessage}`
-      });
-      throw new McpError(
-        ErrorCode.InternalError,
-        `Failed to authenticate with Uptime Kuma: ${errorMessage}`
-      );
+  // The client reports when the authenticated session is known to be gone (socket dropped,
+  // or a re-auth on reconnect was refused). Clearing the flag here is what lets the next
+  // tool call transparently re-authenticate, instead of the process staying wedged.
+  client.onAuthLost = (reason: string) => {
+    if (!isAuthenticated) return;
+    isAuthenticated = false;
+    process.stderr.write(`Uptime Kuma session invalidated: ${reason}. Will re-authenticate on next call.\n`);
+  };
+
+  // UPTIME_KUMA_JWT_TOKEN must be a real JWT — Uptime Kuma verifies it with jwt.verify()
+  // against its jwtSecret. Anything else (a password, an API key, a truncated paste) is
+  // rejected with the opaque message "authInvalidToken", which reads exactly like an
+  // expired credential and sends you looking for a token-lifetime problem that isn't there.
+  // Only the credential's SHAPE is ever reported — never its value.
+  const describeCredential = (): string | null => {
+    const t = config.jwtToken;
+    if (!t) return null;
+    const segments = String(t).split('.').length;
+    if (segments === 3) return null;
+    return `UPTIME_KUMA_JWT_TOKEN is not a JWT: it has ${segments} dot-separated segment(s), expected 3 `
+      + `(length ${String(t).length}). Uptime Kuma will always reject this with "authInvalidToken". `
+      + `Generate a real token with: mcp-uptime-kuma-get-jwt ${config.url} <username> <password>. `
+      + 'Note this variable may also be set in your shell environment as well as your MCP client '
+      + 'config — check both and make sure they agree.';
+  };
+
+  // Function to authenticate the client (to be called after transport is connected).
+  //
+  // Memoised on two axes. Returning early when already authenticated makes it safe to call
+  // from every tool handler; sharing one in-flight promise stops concurrent calls opening a
+  // second socket.io connection during the handshake.
+  const authenticateClient = async (): Promise<void> => {
+    if (isAuthenticated) return;
+    if (authInFlight) return authInFlight;
+
+    authInFlight = (async () => {
+      try {
+        // Reuse a live socket. connect() unconditionally assigns a new one, so every retry
+        // orphaned the previous socket — still holding listeners, still reconnecting.
+        await client.ensureConnected();
+        await client.login(config.username, config.password, config.token, config.jwtToken);
+
+        // Logging in anonymously gives no indication that authentication failed.
+        // So instead, we issue a getSettings call after login, to prove the connection is working.
+        await client.getSettings();
+        isAuthenticated = true;
+
+        await server.sendLoggingMessage({
+          level: 'info',
+          data: 'Successfully authenticated with Uptime Kuma'
+        });
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        const credentialProblem = describeCredential();
+        const detail = credentialProblem ? `${errorMessage}. ${credentialProblem}` : errorMessage;
+        await server.sendLoggingMessage({
+          level: 'error',
+          data: `Failed to authenticate with Uptime Kuma: ${detail}`
+        });
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Failed to authenticate with Uptime Kuma: ${detail}`
+        );
+      }
+    })();
+
+    try {
+      return await authInFlight;
+    } finally {
+      // Always clear the in-flight promise once it settles. Clearing only on failure meant
+      // that after the first success it stayed set forever, so once a session could be
+      // invalidated, authenticateClient() would return that stale resolved promise and skip
+      // re-authenticating entirely.
+      authInFlight = null;
     }
   };
 
@@ -112,12 +162,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ monitorID, includeTypeSpecificFields }) => {
-      if (!isAuthenticated) {
-        throw new McpError(
-          ErrorCode.InternalError,
-          'Not authenticated with Uptime Kuma'
-        );
-      }
+      await authenticateClient();
 
       try {
         const monitor = includeTypeSpecificFields 
@@ -164,12 +209,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ includeTypeSpecificFields, keywords, type, active, maintenance, tags }) => {
-      if (!isAuthenticated) {
-        throw new McpError(
-          ErrorCode.InternalError,
-          'Not authenticated with Uptime Kuma'
-        );
-      }
+      await authenticateClient();
 
       try {
         const monitorList = includeTypeSpecificFields
@@ -272,12 +312,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ keywords, type, active, maintenance, tags, status }) => {
-      if (!isAuthenticated) {
-        throw new McpError(
-          ErrorCode.InternalError,
-          'Not authenticated with Uptime Kuma'
-        );
-      }
+      await authenticateClient();
 
       try {
         const summaries = client.getMonitorSummary({ keywords, type, active, maintenance, tags, status });
@@ -319,12 +354,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ monitorID, maxHeartbeats }) => {
-      if (!isAuthenticated) {
-        throw new McpError(
-          ErrorCode.InternalError,
-          'Not authenticated with Uptime Kuma'
-        );
-      }
+      await authenticateClient();
 
       try {
         const count = maxHeartbeats ?? 1;
@@ -363,12 +393,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async () => {
-      if (!isAuthenticated) {
-        throw new McpError(
-          ErrorCode.InternalError,
-          'Not authenticated with Uptime Kuma'
-        );
-      }
+      await authenticateClient();
 
       try {
         const response = await client.getSettings();
@@ -407,12 +432,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ maxHeartbeats }) => {
-      if (!isAuthenticated) {
-        throw new McpError(
-          ErrorCode.InternalError,
-          'Not authenticated with Uptime Kuma'
-        );
-      }
+      await authenticateClient();
 
       try {
         const count = maxHeartbeats ?? 1;
@@ -460,12 +480,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ monitorID }) => {
-      if (!isAuthenticated) {
-        throw new McpError(
-          ErrorCode.InternalError,
-          'Not authenticated with Uptime Kuma'
-        );
-      }
+      await authenticateClient();
 
       try {
         const response = await client.pauseMonitor(monitorID);
@@ -505,12 +520,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ monitorID }) => {
-      if (!isAuthenticated) {
-        throw new McpError(
-          ErrorCode.InternalError,
-          'Not authenticated with Uptime Kuma'
-        );
-      }
+      await authenticateClient();
 
       try {
         const response = await client.resumeMonitor(monitorID);
@@ -579,9 +589,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async (input) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const defaults: Record<string, unknown> = {
@@ -652,9 +660,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ monitorID, ...rest }) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const existing = client.getMonitor(monitorID, true);
@@ -695,9 +701,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ monitorID }) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const response = await client.deleteMonitor(monitorID);
@@ -726,9 +730,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async () => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const notifications = client.getNotificationList();
@@ -762,9 +764,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ name, type, isDefault, applyExisting, config }) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const notification = { name, type, isDefault, applyExisting, ...config };
@@ -800,9 +800,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ notificationID, name, type, isDefault, applyExisting, config }) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const notification: Record<string, unknown> = { ...config };
@@ -836,9 +834,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ notificationID }) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const response = await client.deleteNotification(notificationID);
@@ -867,9 +863,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async () => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const dockerHosts = client.getDockerHostList();
@@ -901,9 +895,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ name, dockerType, dockerDaemon }) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const response = await client.addDockerHost({ name, dockerType, dockerDaemon });
@@ -936,9 +928,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ dockerHostID, name, dockerType, dockerDaemon }) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         // Merge new values onto the current record so callers can omit unchanged fields.
@@ -981,9 +971,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ dockerHostID }) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const response = await client.deleteDockerHost(dockerHostID);
@@ -1014,9 +1002,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ name, dockerType, dockerDaemon }) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const response = await client.testDockerHost({ name, dockerType, dockerDaemon });
@@ -1049,9 +1035,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async () => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const tags = await client.getTagList();
@@ -1082,9 +1066,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ name, color }) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const response = await client.addTag(name, color);
@@ -1113,9 +1095,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ tagID }) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const response = await client.deleteTag(tagID);
@@ -1144,9 +1124,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async () => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const maintenanceWindows = client.getMaintenanceList();
@@ -1190,9 +1168,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async (input) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const response = await client.createMaintenance(input as Record<string, unknown>);
@@ -1221,9 +1197,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async () => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const statusPages = client.getStatusPageList();
@@ -1255,9 +1229,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ slug }) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const response = await client.getStatusPage(slug);
@@ -1293,9 +1265,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ title, slug }) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const response = await client.createStatusPage(title, slug);
@@ -1327,9 +1297,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ slug, config, publicGroupList, imgDataUrl }) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const response = await client.updateStatusPage(
@@ -1363,9 +1331,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       },
     },
     async ({ slug }) => {
-      if (!isAuthenticated) {
-        throw new McpError(ErrorCode.InternalError, 'Not authenticated with Uptime Kuma');
-      }
+      await authenticateClient();
 
       try {
         const response = await client.deleteStatusPage(slug);

--- a/src/uptime-kuma-client.ts
+++ b/src/uptime-kuma-client.ts
@@ -66,6 +66,13 @@ export class UptimeKumaClient {
   private shouldLog: (level: LoggingLevel) => boolean;
   private loginCredentials: { username: string | undefined; password: string | undefined; token?: string; jwtToken?: string } | null = null;
 
+  /**
+   * Invoked whenever the authenticated session is known to be gone — the socket dropped, or
+   * a re-auth on reconnect was refused. The server layer uses this to clear its
+   * `isAuthenticated` flag so the next tool call re-authenticates instead of failing.
+   */
+  public onAuthLost: ((reason: string) => void) | null = null;
+
   constructor(
     url: string, 
     server?: { sendLoggingMessage: (params: { level: LoggingLevel; data: unknown }) => Promise<void> },
@@ -88,6 +95,29 @@ export class UptimeKumaClient {
         // This handles the case where server is not yet connected to transport
       }
     }
+  }
+
+  /** Report loss of the authenticated session to the server layer. */
+  private notifyAuthLost(reason: string): void {
+    try {
+      if (this.onAuthLost) this.onAuthLost(reason);
+    } catch {
+      // never let a listener error break socket handling
+    }
+  }
+
+  /**
+   * Reuse a live socket instead of blindly opening another one.
+   *
+   * connect() unconditionally assigns a brand-new socket to this.socket, so a retrying
+   * caller orphans the previous one — which keeps its listeners and keeps reconnecting
+   * forever, leaking a socket per attempt. Callers that just want a usable connection
+   * should use this.
+   */
+  async ensureConnected(): Promise<void> {
+    if (this.socket && this.socket.connected) return;
+    if (this.socket) this.disconnect(); // tear the dead one down before replacing it
+    await this.connect();
   }
 
   /**
@@ -114,8 +144,19 @@ export class UptimeKumaClient {
         }
       });
 
+      // There was no 'disconnect' handler at all, so the server layer's isAuthenticated
+      // flag stayed true across a dropped socket. An Uptime Kuma restart — or any network
+      // blip — therefore left this client believing it was still authenticated while the
+      // server treated it as anonymous, and every subsequent call failed until the process
+      // was restarted. Surface the loss so the next call re-authenticates.
+      this.socket.on('disconnect', (reason: string) => {
+        this.safeLog('warning', `Disconnected from Uptime Kuma (${reason}); authentication invalidated`);
+        this.notifyAuthLost(`socket disconnected (${reason})`);
+      });
+
       this.socket.on('connect_error', (error: Error) => {
         this.safeLog('error', `Connection error: ${error.message}`);
+        this.notifyAuthLost(`connection error (${error.message})`);
         if (initialConnect) {
           reject(new Error(`Connection failed: ${error.message}`));
         }
@@ -146,7 +187,10 @@ export class UptimeKumaClient {
         if (response.ok) {
           this.safeLog('info', 'Re-authenticated after reconnection (JWT)');
         } else {
+          // A refused re-auth used to be logged and forgotten, leaving the server layer
+          // convinced it was still authenticated.
           this.safeLog('error', `Re-authentication failed: ${response.msg || 'unknown error'}`);
+          this.notifyAuthLost(`re-authentication refused (${response.msg || 'unknown error'})`);
         }
       });
     } else if (username) {
@@ -154,7 +198,10 @@ export class UptimeKumaClient {
         if (response.ok) {
           this.safeLog('info', 'Re-authenticated after reconnection');
         } else {
+          // A refused re-auth used to be logged and forgotten, leaving the server layer
+          // convinced it was still authenticated.
           this.safeLog('error', `Re-authentication failed: ${response.msg || 'unknown error'}`);
+          this.notifyAuthLost(`re-authentication refused (${response.msg || 'unknown error'})`);
         }
       });
     } else {

--- a/test/unit/auth-session.test.ts
+++ b/test/unit/auth-session.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UptimeKumaClient } from '../../src/uptime-kuma-client.js';
+import { createMockSocket, injectSocket } from './helpers.js';
+
+/**
+ * Session-loss reporting and socket reuse — issue #64.
+ *
+ * `isAuthenticated` in the server layer was a write-once latch: nothing ever cleared it, so
+ * after a dropped socket the MCP believed it was authenticated while Uptime Kuma treated it
+ * as anonymous, and every call failed until the process was restarted.
+ */
+describe('UptimeKumaClient - authenticated session loss', () => {
+  let client: UptimeKumaClient;
+
+  beforeEach(() => {
+    client = new UptimeKumaClient('http://localhost:3001');
+  });
+
+  it('reports session loss through onAuthLost with a reason', () => {
+    const seen: string[] = [];
+    client.onAuthLost = (reason) => seen.push(reason);
+
+    (client as unknown as { notifyAuthLost: (r: string) => void }).notifyAuthLost('socket disconnected (transport close)');
+
+    expect(seen).toEqual(['socket disconnected (transport close)']);
+  });
+
+  it('does not require a listener to be set', () => {
+    expect(() =>
+      (client as unknown as { notifyAuthLost: (r: string) => void }).notifyAuthLost('no listener attached')
+    ).not.toThrow();
+  });
+
+  it('a throwing listener cannot break socket handling', () => {
+    client.onAuthLost = () => { throw new Error('listener blew up'); };
+
+    expect(() =>
+      (client as unknown as { notifyAuthLost: (r: string) => void }).notifyAuthLost('boom')
+    ).not.toThrow();
+  });
+
+  it('ensureConnected reuses a live socket instead of opening another', async () => {
+    const { socket } = createMockSocket();
+    injectSocket(client, socket);
+
+    await client.ensureConnected();
+
+    // connect() unconditionally assigns a new socket, orphaning the old one — which keeps
+    // its listeners and keeps reconnecting. A live socket must be left alone.
+    expect((client as unknown as { socket: unknown }).socket).toBe(socket);
+    expect(socket.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('ensureConnected tears down a dead socket before replacing it', async () => {
+    const dead = { connected: false, emit: vi.fn(), on: vi.fn(), off: vi.fn(), disconnect: vi.fn() };
+    injectSocket(client, dead);
+
+    // Stub connect() so the test does not open a real network connection; we only care that
+    // the dead socket was disposed of first rather than leaked.
+    const connect = vi.fn(async () => { injectSocket(client, { connected: true }); });
+    (client as unknown as { connect: unknown }).connect = connect;
+
+    await client.ensureConnected();
+
+    expect(dead.disconnect).toHaveBeenCalled();
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes #64. Independent of #69 and #70 — touches the authentication path only.

## The latch

`isAuthenticated` is written once and never cleared, and nothing ever retries. So once the server decides it isn't authenticated, it stays that way for the life of the process. Two reproducible consequences:

**A. A tool call arriving before startup authentication completes fails.** stdio serves tools as soon as the transport connects, so this is a race — and an MCP client that calls a tool immediately after `initialize` loses it every time.

**B. If Uptime Kuma is unreachable at startup, the server exits.** `runStdio` catches the authentication error and calls `process.exit(1)`. A monitoring host being briefly down — a container restart, a host still booting — takes the MCP server with it, permanently, until the client relaunches it.

## Measured before / after

Same throwaway Uptime Kuma 2.4.0, same script, only the build differs:

| | upstream `main` | this branch |
|---|---|---|
| call at +3ms | `Not authenticated with Uptime Kuma` | `OK count=14` |
| Kuma down at startup | **process exits** | stays up |
| call while Kuma down | `server process has exited` | `Connection failed: xhr poll error` |
| call after Kuma returns | `server process has exited` | `OK count=14` |

The bottom-left cell is the one that matters: on `main` there is no recovery, because there is no process left to recover.

Worth noting what is *already* fine — #30 added `reauthenticate()` on socket.io reconnect, and it works: a clean Kuma restart recovers on `main` today. I checked that before writing this, and it's why the fix here is narrower than #64's title suggests. The gap is startup and session-loss, not reconnect.

## Changes

- **`authenticateClient()` is memoised.** Returns early when already authenticated, so it's safe to call from every handler; concurrent callers share one in-flight promise rather than opening a second socket.io connection mid-handshake.
- **The 30 `if (!isAuthenticated) throw` guards become `await authenticateClient()`.** A call arriving mid-handshake waits instead of failing; a call after a lost session re-authenticates instead of failing forever.
- **`authInFlight` is cleared in a `finally`,** not only on failure. This was latent: after the first success it stayed set forever, so once a session *could* be invalidated, `authenticateClient()` would return that stale resolved promise and skip re-authenticating entirely. Fixing the latch without this would have produced a subtler version of the same bug.
- **A startup auth failure no longer exits the process.** Logged, and each tool call retries lazily.
- **`onAuthLost` hook on the client,** fired from a new `disconnect` handler (there was none at all), from `connect_error`, and from a refused re-auth — which was previously logged and forgotten, leaving the server convinced it was still authenticated.
- **`ensureConnected()` reuses a live socket.** `connect()` unconditionally assigned a new one, so every retry orphaned the previous socket — still holding listeners, still reconnecting.
- **A non-JWT credential is named as such.** Uptime Kuma rejects it with the opaque `authInvalidToken`, which reads exactly like an expired token; that cost me two days of looking for a token-lifetime problem that didn't exist. Only the credential's **shape** is ever reported — never its value.

## Testing

- 5 new unit tests for session-loss reporting and socket reuse, including that a throwing `onAuthLost` listener can't break socket handling.
- 89 existing unit tests unaffected.
- The before/after table above, run against a live instance.
