### PR TITLE
fix: withhold credentials from the read tools by default (#59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,51 @@ docker run --rm davidfuchs/mcp-uptime-kuma:latest get-jwt http://host.docker.int
 
 **From browser:** Open Developer Tools → Storage/Application → Local Storage → find `token` key.
 
+## Credential Redaction
+
+Read tools return `***` in place of secrets rather than the values themselves.
+
+Uptime Kuma's socket API returns configuration verbatim — its web UI masks credentials at
+render time. That is fine for a browser and not fine for an MCP server, whose output lands
+in an LLM's context window and is then persisted in conversation transcripts, logs and
+synced history. Asking "what am I monitoring?" should not write a live SMTP password or a
+third-party API key into storage you may not control.
+
+What is withheld:
+
+| Tool | Withheld |
+|---|---|
+| `listNotifications` | everything in `config` except `type`/`name`/`isDefault`/`applyExisting`. The withheld field names are listed in `redactedConfigKeys` |
+| `listMonitors`, `getMonitor` | `pushToken`, `basic_auth_pass`, `bearer_token`, `oauth_client_secret`, `radiusPassword`, `radiusSecret`, `mqttPassword`, `rabbitmqPassword`, `tlsCert`/`tlsKey`/`tlsCa`, `databaseConnectionString`, `headers`, `grpcMetadata`, plus anything matching `/pass|secret|token|apikey|auth(oriz\|entic)|bearer|credential|private.?key|jwt/i` |
+| `listDockerHosts` | `user:password@` inside a `dockerDaemon` URL |
+| `getSettings` | any secret-named field Uptime Kuma returns (e.g. `steamAPIKey`) |
+| `getMonitorSummary` | nothing — it returns no credentials to begin with |
+
+`hostname`, `port`, `url`, `authMethod`, `oauth_token_url`, `oauth_scopes` and usernames stay
+visible: hiding useful configuration is how a redaction feature gets switched off.
+
+To get the real values, either pass `includeSecrets: true` on the call:
+
+```
+listNotifications({ includeSecrets: true })
+```
+
+or enable it globally:
+
+```
+UPTIME_KUMA_INCLUDE_SECRETS=true
+```
+
+The per-call parameter wins over the environment variable in both directions, so a
+permissive deployment can still ask one call to redact.
+
+**Writing `***` back is safe.** `updateMonitor` and `updateNotification` restore the stored
+value when a field arrives as the marker, and report which fields they preserved. This
+matters most for `updateNotification`: Uptime Kuma replaces the notification row rather than
+merging it, so without this a read-edit-write round trip would replace a working password
+with three asterisks. If there is no stored value to restore, the call fails rather than
+writing a credential that looks set and cannot work.
+
 ## LibreChat Configuration
 
 **stdio transport:**

--- a/README.md
+++ b/README.md
@@ -236,6 +236,11 @@ merging it, so without this a read-edit-write round trip would replace a working
 with three asterisks. If there is no stored value to restore, the call fails rather than
 writing a credential that looks set and cannot work.
 
+`updateDockerHost` gets the same protection for the credentials embedded in a `dockerDaemon`
+URL: a `http://***:***@host:2375` read back from `listDockerHosts` has its userinfo restored
+from the stored URL rather than persisted verbatim, so repointing a host without re-entering
+its credentials does not wipe them.
+
 ## LibreChat Configuration
 
 **stdio transport:**

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,9 @@ function validateEnvironment(): UptimeKumaConfig {
   const password = process.env.UPTIME_KUMA_PASSWORD;
   const token = process.env.UPTIME_KUMA_2FA_TOKEN;
   const jwtToken = process.env.UPTIME_KUMA_JWT_TOKEN;
+  // Global opt-in to unredacted credentials in read-tool output (issue #59). Only an
+  // explicit "true"/"1" enables it — an unset or misspelled value must fail closed.
+  const includeSecrets = /^(true|1)$/i.test(process.env.UPTIME_KUMA_INCLUDE_SECRETS ?? '');
 
   if (!url) {
     console.error('Error: UPTIME_KUMA_URL environment variable is required');
@@ -44,7 +47,7 @@ function validateEnvironment(): UptimeKumaConfig {
     );
   }
 
-  return { url, username, password, token, jwtToken };
+  return { url, username, password, token, jwtToken, includeSecrets };
 }
 
 // Parse command-line arguments

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -272,6 +272,73 @@ export function rehydrateSecrets(
 }
 
 /**
+ * Restores inline URL credentials that a redacted read scrubbed to the marker.
+ *
+ * `redactUrlCredentials` turns `http://user:pass@host` into `http://***:***@host`, and that
+ * scrubbed form is NOT the bare `***` that `rehydrateSecrets` recognises — the marker lives
+ * inside the URL's userinfo, not as the whole field value. A `dockerDaemon` TCP endpoint is the
+ * field that carries this, and `updateDockerHost` writes the whole value back, so without this a
+ * read-edit-write loop persists `***:***@host` and wipes the credential — the exact clobber
+ * `rehydrateSecrets` prevents for monitors and notifications.
+ *
+ * Returns the restored URL and whether a marker was restored (`preserved`) or had nothing behind
+ * it (`missing` — a create, or a stored URL that never had that credential). A URL with no marker
+ * in its userinfo, or a non-URL string, is returned unchanged.
+ */
+export function rehydrateUrlCredentials(
+  incoming: string,
+  stored: string | undefined
+): { value: string; preserved: boolean; missing: boolean } {
+  if (typeof incoming !== 'string' || !/^[a-z][a-z0-9+.-]*:\/\//i.test(incoming)) {
+    return { value: incoming, preserved: false, missing: false };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(incoming);
+  } catch {
+    return { value: incoming, preserved: false, missing: false };
+  }
+
+  if (url.username !== SECRET_MARKER && url.password !== SECRET_MARKER) {
+    return { value: incoming, preserved: false, missing: false };
+  }
+
+  let storedUrl: URL | undefined;
+  if (typeof stored === 'string') {
+    try {
+      storedUrl = new URL(stored);
+    } catch {
+      storedUrl = undefined;
+    }
+  }
+
+  let preserved = false;
+  let missing = false;
+
+  if (url.username === SECRET_MARKER) {
+    const previous = storedUrl?.username;
+    if (previous) {
+      url.username = previous;
+      preserved = true;
+    } else {
+      missing = true;
+    }
+  }
+  if (url.password === SECRET_MARKER) {
+    const previous = storedUrl?.password;
+    if (previous) {
+      url.password = previous;
+      preserved = true;
+    } else {
+      missing = true;
+    }
+  }
+
+  return { value: url.toString(), preserved, missing };
+}
+
+/**
  * Shared wording for the opt-in, so every tool describes it the same way.
  */
 export const INCLUDE_SECRETS_DESCRIPTION =

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,0 +1,279 @@
+/**
+ * Redaction of secrets on the way OUT of the read tools (issue #59).
+ *
+ * Uptime Kuma's socket API returns notification and monitor configuration verbatim,
+ * secrets included — its own web UI masks them at render time. That is fine for a
+ * browser and not fine here: an MCP server's output lands in an LLM's context window
+ * and is then persisted in client-side conversation transcripts, logs and synced
+ * history. A routine "what am I monitoring?" therefore writes live SMTP credentials,
+ * push tokens and third-party API keys into storage the user may not control.
+ *
+ * Two rules make this safe, and both matter more than the field lists below:
+ *
+ * 1. REDACTION HAPPENS AT THE TOOL OUTPUT BOUNDARY, NEVER IN THE CLIENT OR CACHE.
+ *    `updateMonitor` reads the existing monitor and merges the caller's changes over
+ *    it; `getNotificationList()` hands back references straight out of
+ *    `notificationListCache`. Redacting in either place would mean the next write
+ *    persists "***" over a working credential. Every function here returns a COPY and
+ *    the write paths keep reading unredacted.
+ *
+ * 2. A VALUE THAT COMES BACK IN IS RESTORED, NOT WRITTEN. See `rehydrateSecrets` —
+ *    the read-edit-write loop an agent naturally performs must not destroy the secret
+ *    it was never shown.
+ */
+
+/**
+ * What a withheld value is replaced with. Callers can still see that the field is
+ * SET without learning its value, and `rehydrateSecrets` recognises it on the way back.
+ */
+export const SECRET_MARKER = '***';
+
+/**
+ * Keys are compared case-insensitively with separators removed, so `push_token`
+ * (the database column) and `pushToken` (what Uptime Kuma's socket payload calls it)
+ * are one entry rather than two. Every set below is written in this normalised form.
+ */
+const normaliseKey = (key: string): string => key.toLowerCase().replace(/[_-]/g, '');
+
+/**
+ * Safety net for fields Uptime Kuma has not added yet.
+ *
+ * Deliberately narrower than the obvious `/auth/` on the `auth` alternative: a bare
+ * `auth` also matches `authMethod`, `oauth_auth_method` and `oauth_scopes`, which are
+ * genuinely useful configuration and not credentials. Hiding them would make the
+ * redaction itself the reason someone turns it off.
+ */
+export const SECRET_KEY_PATTERN =
+  /pass(word|wd|phrase)?|secret|token|apikey|api_key|auth(oriz|entic)|bearer|credential|private.?key|jwt/i;
+
+/**
+ * Sensitive fields the pattern above does NOT catch, mostly because their names say
+ * what they hold rather than that it is secret.
+ */
+const EXPLICIT_SECRET_KEYS = new Set(
+  [
+    // Free-form, and in practice where third-party API keys live. Masked wholesale:
+    // the contents are caller-defined, so there is no key list to be selective with.
+    'headers',
+    'grpcmetadata',
+    // Connection strings normally carry user:password inline.
+    'databaseconnectionstring',
+    // Client certificates and their keys.
+    'tlsca',
+    'tlscert',
+    'tlskey',
+    // Not a credential on its own, but it is half of one and was named in #59.
+    'oauthclientid',
+  ].map(normaliseKey)
+);
+
+/**
+ * Fields that LOOK sensitive to the pattern but are not, and are useful to see.
+ * Checked before everything else.
+ *
+ * `oauth_token_url` is the motivating case: it matches `token` and is an endpoint.
+ */
+const NEVER_SECRET_KEYS = new Set(
+  ['oauthtokenurl', 'tokenurl', 'authmethod', 'oauthauthmethod', 'oauthscopes', 'oauthaudience'].map(
+    normaliseKey
+  )
+);
+
+/** Whether a field name should have its value withheld. */
+export function isSecretKey(key: string): boolean {
+  const k = normaliseKey(key);
+  if (NEVER_SECRET_KEYS.has(k)) return false;
+  if (EXPLICIT_SECRET_KEYS.has(k)) return true;
+  return SECRET_KEY_PATTERN.test(key);
+}
+
+/**
+ * Strips `user:password@` out of a URL while leaving the rest readable.
+ *
+ * A monitor `url`, a `dockerDaemon` TCP endpoint and every entry of `rabbitmqNodes`
+ * can all carry inline credentials, and none of those field NAMES suggest a secret.
+ * Replacing the whole value would hide the endpoint too — and would break
+ * `rabbitmqNodes`, whose schema requires each entry to still be a valid URL.
+ */
+export function redactUrlCredentials(value: string): string {
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return value;
+  try {
+    const url = new URL(value);
+    if (!url.username && !url.password) return value;
+    if (url.username) url.username = SECRET_MARKER;
+    if (url.password) url.password = SECRET_MARKER;
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Recursive copy with secret-named fields replaced by the marker.
+ *
+ * Recursion is not decoration: `kafkaProducerSaslOptions` is an OBJECT holding
+ * `{mechanism, username, password}`. Masking it wholesale would hide the mechanism
+ * and violate its own schema, so the password inside it is masked and the rest kept.
+ */
+export function redactSecrets<T>(value: T, keyHint?: string): T {
+  if (typeof value === 'string') {
+    return redactUrlCredentials(value) as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => redactSecrets(v, keyHint)) as unknown as T;
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (v === null || v === undefined || v === '') {
+      // An unset secret is not a secret, and reporting "***" for an empty field
+      // would claim a credential exists where none does.
+      out[k] = v;
+    } else if (isSecretKey(k)) {
+      out[k] = SECRET_MARKER;
+    } else {
+      out[k] = redactSecrets(v, k);
+    }
+  }
+  return out as unknown as T;
+}
+
+/**
+ * Notification `config` blobs use an ALLOWLIST rather than the denylist above.
+ *
+ * The set of notification providers is large and each one names its credential
+ * differently, so a denylist is a promise to keep up with upstream forever. The
+ * fields below are the ones every provider shares and none of them is a secret;
+ * everything else is withheld and NAMED in `redactedConfigKeys`, which is enough
+ * to see that a field is set and to ask for it explicitly.
+ *
+ * Widening this is a one-line change per field, and safe as long as the field is
+ * common to all providers.
+ */
+const NOTIFICATION_CONFIG_ALLOW = new Set(
+  ['type', 'name', 'isdefault', 'applyexisting', 'active', 'id'].map(normaliseKey)
+);
+
+export interface RedactedNotification extends Record<string, unknown> {
+  redactedConfigKeys?: string[];
+}
+
+/**
+ * Applies the allowlist to one notification row.
+ *
+ * The row's own columns (`id`, `name`, `type`, `active`, `isDefault`) are not secret
+ * and are kept as-is. `config` is a JSON STRING holding the provider-specific fields,
+ * and is where every credential lives. It is returned as a JSON string of the
+ * allowlisted subset so the field keeps its shape, alongside `redactedConfigKeys`
+ * naming what was withheld.
+ */
+export function redactNotification(notification: Record<string, unknown>): RedactedNotification {
+  const out: RedactedNotification = {};
+  for (const [k, v] of Object.entries(notification)) {
+    if (k !== 'config') out[k] = v;
+  }
+
+  const raw = notification['config'];
+  let parsed: Record<string, unknown> | undefined;
+  if (typeof raw === 'string') {
+    try {
+      const candidate: unknown = JSON.parse(raw);
+      if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
+        parsed = candidate as Record<string, unknown>;
+      }
+    } catch {
+      // Unparseable config could be anything, so it is withheld in full rather
+      // than guessed at.
+      out['config'] = SECRET_MARKER;
+      out.redactedConfigKeys = [];
+      return out;
+    }
+  } else if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    parsed = raw as Record<string, unknown>;
+  }
+
+  if (!parsed) {
+    if (raw !== undefined) out['config'] = raw;
+    return out;
+  }
+
+  const kept: Record<string, unknown> = {};
+  const withheld: string[] = [];
+  for (const [k, v] of Object.entries(parsed)) {
+    if (NOTIFICATION_CONFIG_ALLOW.has(normaliseKey(k))) {
+      kept[k] = v;
+    } else {
+      withheld.push(k);
+    }
+  }
+
+  out['config'] = typeof raw === 'string' ? JSON.stringify(kept) : kept;
+  out.redactedConfigKeys = withheld;
+  return out;
+}
+
+export function redactNotifications(notifications: Record<string, unknown>[]): RedactedNotification[] {
+  return notifications.map(redactNotification);
+}
+
+/**
+ * Restores values the caller was never shown, instead of writing the marker over them.
+ *
+ * This is the half of #59 that decides whether redaction is safe to ship at all. The
+ * natural agent loop is read → edit one field → write the whole object back, and after
+ * a read the object it holds says `smtpPassword: "***"`. Without this, renaming a
+ * notification channel would replace its password with three asterisks.
+ *
+ * Mutates `incoming` in place — every caller passes an object it just built.
+ *
+ * Passing `stored` as undefined turns this into a pure check: every marker is reported as
+ * `missing`, which is what the CREATE paths want. There is nothing to restore on a create,
+ * so a marker there would persist three asterisks as a real credential.
+ *
+ * Known trade-off: a credential whose real value is literally `***` cannot be set through
+ * an update, because it is indistinguishable from the marker. Passing it on create still
+ * fails for the same reason. Both are preferable to the alternative — silently writing the
+ * marker over a working secret is the failure this exists to prevent.
+ */
+export function rehydrateSecrets(
+  incoming: Record<string, unknown>,
+  stored: Record<string, unknown> | undefined
+): { preserved: string[]; missing: string[] } {
+  const preserved: string[] = [];
+  const missing: string[] = [];
+
+  for (const [k, v] of Object.entries(incoming)) {
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      const nested = stored?.[k];
+      const result = rehydrateSecrets(
+        v as Record<string, unknown>,
+        nested && typeof nested === 'object' ? (nested as Record<string, unknown>) : undefined
+      );
+      preserved.push(...result.preserved.map((p) => `${k}.${p}`));
+      missing.push(...result.missing.map((p) => `${k}.${p}`));
+      continue;
+    }
+    if (v !== SECRET_MARKER) continue;
+
+    const previous = stored?.[k];
+    if (previous === undefined || previous === null || previous === '') {
+      // Nothing to put back. Writing the marker would be worse than refusing:
+      // it creates a credential that looks set and cannot work.
+      missing.push(k);
+    } else {
+      incoming[k] = previous;
+      preserved.push(k);
+    }
+  }
+
+  return { preserved, missing };
+}
+
+/**
+ * Shared wording for the opt-in, so every tool describes it the same way.
+ */
+export const INCLUDE_SECRETS_DESCRIPTION =
+  'Return credentials in full instead of "***". Off by default: this output is persisted in ' +
+  'conversation transcripts and logs. Can also be enabled globally with UPTIME_KUMA_INCLUDE_SECRETS=true.';

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,7 @@ import {
   redactNotifications,
   redactSecrets,
   rehydrateSecrets,
+  rehydrateUrlCredentials,
 } from './redact.js';
 import { VERSION } from './version.js';
 
@@ -1311,9 +1312,35 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
           dockerDaemon: dockerDaemon ?? existing.dockerDaemon,
         };
 
+        // Issue #59: listDockerHosts scrubs inline URL credentials to "***:***@host", and a
+        // dockerDaemon TCP URL is written back here wholesale. The read-edit-write loop an agent
+        // performs would otherwise persist those markers over the real credentials. Restore them
+        // from the stored URL. The marker sits inside the URL userinfo, not as a bare "***", so
+        // rehydrateSecrets cannot catch it — rehydrateUrlCredentials is its URL-shaped counterpart.
+        // Only reached when the caller passed dockerDaemon; omitting it already keeps the stored URL.
+        let preservedCreds = false;
+        if (dockerDaemon !== undefined) {
+          const restored = rehydrateUrlCredentials(dockerDaemon, existing.dockerDaemon);
+          if (restored.missing) {
+            throw new Error(
+              'Cannot write the redaction marker "***" into dockerDaemon — the docker host has no ' +
+              'stored credential to restore, so this would save an endpoint that looks authenticated ' +
+              'and cannot connect. Pass the real URL, or call listDockerHosts with includeSecrets to ' +
+              'read the current one.'
+            );
+          }
+          merged.dockerDaemon = restored.value;
+          preservedCreds = restored.preserved;
+        }
+
         const response = await client.addDockerHost(merged, dockerHostID);
+        let text = response.msg || `Docker host ${dockerHostID} updated`;
+        if (preservedCreds) {
+          text += '\n\nKept the existing credentials embedded in dockerDaemon — "***" was sent, ' +
+            'which is the redaction marker, not a credential.';
+        }
         return {
-          content: [{ type: 'text', text: response.msg || `Docker host ${dockerHostID} updated` }],
+          content: [{ type: 'text', text }],
           structuredContent: { ok: response.ok, id: response.id, msg: response.msg },
         };
       } catch (error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,12 @@ import { randomBytes, randomInt } from 'node:crypto';
 import { UptimeKumaClient } from './uptime-kuma-client.js';
 import { HeartbeatSchema, MonitorBaseSchema, MonitorSummarySchema, SettingsSchema, NotificationSchema, MaintenanceSchema, StatusPageSchema, DockerHostSchema } from './types/index.js';
 import type { UptimeKumaConfig } from './types/index.js';
+import {
+  INCLUDE_SECRETS_DESCRIPTION,
+  redactNotifications,
+  redactSecrets,
+  rehydrateSecrets,
+} from './redact.js';
 import { VERSION } from './version.js';
 
 /**
@@ -43,6 +49,15 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         - Use 'testDockerHost' to verify a docker daemon is reachable before saving.
         - Use 'createStatusPage' / 'updateStatusPage' / 'deleteStatusPage' to manage status pages. Creating returns an empty page — follow up with updateStatusPage to set groups and monitors.
         - Use 'pauseMonitor' / 'resumeMonitor' to temporarily stop/start checks.
+
+        CREDENTIALS:
+        - Read tools return "***" in place of passwords, tokens, API keys and HTTP headers.
+          To attach a notification channel to a monitor you only need its id, so the common
+          workflows never need the real values.
+        - Pass includeSecrets: true (or set UPTIME_KUMA_INCLUDE_SECRETS=true) only when the
+          value itself is needed. It will be written to this conversation's transcript.
+        - "***" sent back to updateMonitor / updateNotification restores the stored value
+          rather than overwriting it, so a read-edit-write round trip is safe.
       `,
       capabilities: {
         logging: {}
@@ -147,6 +162,18 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
   };
   
   const client = new UptimeKumaClient(config.url, server, shouldLog);
+
+  // Issue #59: read tools withhold credentials by default. Captured here because the
+  // registerTool wrapper above shadows `config` with the per-tool registration object.
+  //
+  // The env var is the global switch and the per-call `includeSecrets` parameter is the
+  // narrow one; the parameter wins where both are present, in either direction, so a
+  // globally-permissive deployment can still ask a single call to redact.
+  const includeSecretsByDefault = config.includeSecrets === true;
+  const wantsSecrets = (perCall?: boolean): boolean =>
+    perCall === undefined ? includeSecretsByDefault : perCall;
+  const includeSecretsParam = z.boolean().optional().describe(INCLUDE_SECRETS_DESCRIPTION);
+
   let isAuthenticated = false;
   let authInFlight: Promise<void> | null = null;
 
@@ -233,28 +260,31 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
     {
       title: 'Get Monitor',
       description: 'Retrieves configuration details for a specific monitor by ID (URL, check interval, notification settings, etc.). Use this when you need to examine or modify settings for a specific monitor. For current status, use getMonitorSummary instead. By default returns only common fields plus runtime data (uptime, avgPing); set includeTypeSpecificFields to true to include type-specific fields (e.g., url for HTTP, hostname/port for TCP).',
-      inputSchema: { 
+      inputSchema: {
         monitorID: z.coerce.number().int().nonnegative().describe('The ID of the monitor to retrieve'),
-        includeTypeSpecificFields: z.boolean().optional().describe('Include type-specific fields (url, hostname, port, etc.) in addition to common fields. Default: false. When false, only returns MonitorBase fields plus uptime/avgPing.')
+        includeTypeSpecificFields: z.boolean().optional().describe('Include type-specific fields (url, hostname, port, etc.) in addition to common fields. Default: false. When false, only returns MonitorBase fields plus uptime/avgPing.'),
+        includeSecrets: includeSecretsParam
       },
-      outputSchema: { 
-        monitor: MonitorBaseSchema.passthrough().describe('Monitor object with common fields plus uptime/avgPing. May include type-specific fields when includeTypeSpecificFields is true.')
+      outputSchema: {
+        monitor: MonitorBaseSchema.passthrough().describe('Monitor object with common fields plus uptime/avgPing. May include type-specific fields when includeTypeSpecificFields is true. Credentials (pushToken, basic_auth_pass, bearer_token, headers, ...) read "***" unless includeSecrets is set.')
       },
     },
-    async ({ monitorID, includeTypeSpecificFields }) => {
+    async ({ monitorID, includeTypeSpecificFields, includeSecrets }) => {
       await authenticateClient();
 
       try {
-        const monitor = includeTypeSpecificFields 
+        const monitor = includeTypeSpecificFields
           ? client.getMonitor(monitorID, true)
           : client.getMonitor(monitorID, false);
-        
+
         if (!monitor) {
           throw new Error(`Monitor with ID ${monitorID} not found`);
         }
-        
-        const result = monitor;
-        
+
+        // Redact on a copy. getMonitor() spreads the cached row, but nested values are
+        // still shared with monitorListCache — which updateMonitor merges over on write.
+        const result = wantsSecrets(includeSecrets) ? monitor : redactSecrets(monitor);
+
         return {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
           structuredContent: { monitor: result },
@@ -284,22 +314,26 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         tags: z.string().optional().describe('Filter by tag name and optional value. Comma-separated for multiple tags. Format: "tagName" or "tagName=value". Monitor must have all specified tags. Case-insensitive. Examples: "production", "env=staging", "production,region=us-east"'),
         // Issue #65: there was no way to list a group's members, so callers passing
         // `parentId` got the entire monitor list back, which reads as a broken filter.
-        parentId: z.union([z.null(), z.coerce.number().int()]).optional().describe('Filter to the DIRECT children of this group monitor. Pass null for top-level monitors (those with no parent). Not recursive — use the group\'s own childrenIDs to walk deeper.')
+        parentId: z.union([z.null(), z.coerce.number().int()]).optional().describe('Filter to the DIRECT children of this group monitor. Pass null for top-level monitors (those with no parent). Not recursive — use the group\'s own childrenIDs to walk deeper.'),
+        includeSecrets: includeSecretsParam
       },
       outputSchema: {
-        monitors: z.array(MonitorBaseSchema.passthrough()).describe('Array of monitor objects with common fields plus uptime/avgPing. May include type-specific fields when includeTypeSpecificFields is true.'),
+        monitors: z.array(MonitorBaseSchema.passthrough()).describe('Array of monitor objects with common fields plus uptime/avgPing. May include type-specific fields when includeTypeSpecificFields is true. Credentials (pushToken, basic_auth_pass, bearer_token, headers, ...) read "***" unless includeSecrets is set.'),
         count: z.number()
       },
     },
-    async ({ includeTypeSpecificFields, keywords, type, active, maintenance, tags, parentId }) => {
+    async ({ includeTypeSpecificFields, keywords, type, active, maintenance, tags, parentId, includeSecrets }) => {
       await authenticateClient();
 
       try {
         const monitorList = includeTypeSpecificFields
           ? client.getMonitorList({ keywords, type, active, maintenance, tags, parentId, includeTypeSpecificFields: true })
           : client.getMonitorList({ keywords, type, active, maintenance, tags, parentId, includeTypeSpecificFields: false });
-        const monitors = Object.values(monitorList);
-        
+        const raw = Object.values(monitorList);
+        // This is the tool an agent reaches for to answer "what am I monitoring?", so it
+        // is both the highest-volume caller and the one carrying the most credentials.
+        const monitors = wantsSecrets(includeSecrets) ? raw : raw.map((m) => redactSecrets(m));
+
         return {
           content: [{ 
             type: 'text', 
@@ -470,24 +504,31 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
     {
       title: 'Get Settings',
       description: 'Retrieves the current Uptime Kuma server settings including timezone, authentication status, primary base URL, and other configuration options.',
-      inputSchema: {},
+      inputSchema: {
+        includeSecrets: includeSecretsParam
+      },
       outputSchema: {
         settings: SettingsSchema.describe('Current Uptime Kuma server settings')
       },
     },
-    async () => {
+    async ({ includeSecrets }) => {
       await authenticateClient();
 
       try {
         const response = await client.getSettings();
-        
+
         if (!response.data) {
           throw new Error('No settings data returned');
         }
-        
+
+        // SettingsSchema declares a safe subset, but the text content below stringifies
+        // whatever Uptime Kuma actually sent — which includes steamAPIKey. Redacting the
+        // object covers both channels; redacting only structuredContent would not.
+        const settings = wantsSecrets(includeSecrets) ? response.data : redactSecrets(response.data);
+
         return {
-          content: [{ type: 'text', text: JSON.stringify(response.data, null, 2) }],
-          structuredContent: { settings: response.data },
+          content: [{ type: 'text', text: JSON.stringify(settings, null, 2) }],
+          structuredContent: { settings },
         };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -756,6 +797,16 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
 
         const requested = normaliseMonitorAliases({ ...input } as Record<string, unknown>);
 
+        // Issue #59: nothing to restore on a create, so the redaction marker must be refused
+        // rather than persisted — writing "***" produces a credential that looks set and can
+        // never work. Reached by copying a redacted monitor to make a similar one.
+        const markers = rehydrateSecrets(requested, undefined).missing;
+        if (markers.length > 0) {
+          throw new Error(
+            `"***" is the redaction marker, not a credential — pass the real value for ${markers.join(', ')}, or omit the field.`
+          );
+        }
+
         // A json-query monitor without a query is accepted by Uptime Kuma and then fails
         // every single check, which looks like a broken target rather than a broken config.
         if (requested.type === 'json-query') {
@@ -903,6 +954,23 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
           }
         }
         normaliseMonitorAliases(defined);
+
+        // Issue #59: a caller that read this monitor back holds "***" where a credential
+        // was, and the natural edit-one-field-and-write-it-back loop would then persist
+        // the marker. Restore the stored value instead. Runs AFTER alias normalisation so
+        // `push_token: "***"` is matched against the stored `pushToken`.
+        //
+        // `existing` is the unredacted cache row: redaction lives at the tool output
+        // boundary only, precisely so this comparison still has a real value to find.
+        const { preserved, missing } = rehydrateSecrets(defined, existing as unknown as Record<string, unknown>);
+        if (missing.length > 0) {
+          throw new Error(
+            `Cannot write the redaction marker "***" to ${missing.join(', ')} — the monitor has no stored value ` +
+            'to restore, so this would create a credential that looks set and cannot work. ' +
+            'Pass the real value, or omit the field to leave it unchanged.'
+          );
+        }
+
         const merged = { ...existing, ...defined, id: monitorID };
         // Ensure retryInterval is valid — Kuma rejects values < 1 on edit even if
         // it stored 0 during creation (pre-existing monitors or older defaults)
@@ -910,8 +978,12 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
           (merged as any).retryInterval = (merged as any).interval || 60;
         }
         const response = await client.updateMonitor(merged as unknown as Record<string, unknown>);
+        let text = response.msg || `Monitor ${monitorID} updated successfully`;
+        if (preserved.length > 0) {
+          text += `\n\nKept the existing value for ${preserved.join(', ')} — "***" was sent, which is the redaction marker, not a credential.`;
+        }
         return {
-          content: [{ type: 'text', text: response.msg || `Monitor ${monitorID} updated successfully` }],
+          content: [{ type: 'text', text }],
           structuredContent: { ok: response.ok, monitorID: response.monitorID, msg: response.msg },
         };
       } catch (error) {
@@ -956,18 +1028,25 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
     'listNotifications',
     {
       title: 'List Notifications',
-      description: 'Returns all configured notification channels (Slack, ntfy, Discord, email, webhooks, etc.).',
-      inputSchema: {},
+      description: 'Returns all configured notification channels (Slack, ntfy, Discord, email, webhooks, etc.). To attach a channel to a monitor you only need its id — the credentials in `config` are withheld by default and the names of the withheld fields are listed in `redactedConfigKeys`.',
+      inputSchema: {
+        includeSecrets: includeSecretsParam
+      },
       outputSchema: {
-        notifications: z.array(NotificationSchema).describe('Array of notification channel configurations'),
+        notifications: z.array(NotificationSchema).describe('Array of notification channel configurations. By default `config` is reduced to its non-secret fields and `redactedConfigKeys` names what was withheld.'),
         count: z.number(),
       },
     },
-    async () => {
+    async ({ includeSecrets }) => {
       await authenticateClient();
 
       try {
-        const notifications = client.getNotificationList();
+        const raw = client.getNotificationList();
+        // getNotificationList() returns references into notificationListCache, so this
+        // must not mutate — redactNotifications builds new objects.
+        const notifications = wantsSecrets(includeSecrets)
+          ? raw
+          : redactNotifications(raw as unknown as Record<string, unknown>[]);
         return {
           content: [{ type: 'text', text: JSON.stringify(notifications, null, 2) }],
           structuredContent: { notifications, count: notifications.length },
@@ -1002,6 +1081,18 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
 
       try {
         const notification = { name, type, isDefault, applyExisting, ...config };
+
+        // Issue #59: as with createMonitor, there is no stored value to restore on a create,
+        // so the redaction marker is refused rather than saved as the credential. This is the
+        // path you hit cloning an existing channel from a redacted listNotifications.
+        const markers = rehydrateSecrets(notification as Record<string, unknown>, undefined).missing;
+        if (markers.length > 0) {
+          throw new Error(
+            `"***" is the redaction marker, not a credential — pass the real value for ${markers.join(', ')}. ` +
+            'To copy an existing channel, read it with listNotifications { includeSecrets: true }.'
+          );
+        }
+
         const response = await client.addNotification(notification as Record<string, unknown>);
         return {
           content: [{ type: 'text', text: response.msg || `Notification created with ID ${response.id}` }],
@@ -1042,9 +1133,45 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         if (type !== undefined) notification['type'] = type;
         if (isDefault !== undefined) notification['isDefault'] = isDefault;
         if (applyExisting !== undefined) notification['applyExisting'] = applyExisting;
+
+        // Issue #59, and the sharper edge of it. Uptime Kuma's addNotification REPLACES the
+        // row rather than merging, so the read-edit-write loop writes back whatever the
+        // caller was shown — and after redaction that is `smtpPassword: "***"`. Renaming a
+        // channel would otherwise destroy the credential that makes it work.
+        const stored = client
+          .getNotificationList()
+          .find((n) => (n as Record<string, unknown>)['id'] === notificationID) as
+          | Record<string, unknown>
+          | undefined;
+        let storedConfig: Record<string, unknown> | undefined;
+        const rawStored = stored?.['config'];
+        if (typeof rawStored === 'string') {
+          try {
+            const parsed: unknown = JSON.parse(rawStored);
+            if (parsed && typeof parsed === 'object') storedConfig = parsed as Record<string, unknown>;
+          } catch {
+            storedConfig = undefined;
+          }
+        } else if (rawStored && typeof rawStored === 'object') {
+          storedConfig = rawStored as Record<string, unknown>;
+        }
+
+        const { preserved, missing } = rehydrateSecrets(notification, storedConfig);
+        if (missing.length > 0) {
+          throw new Error(
+            `Cannot write the redaction marker "***" to ${missing.join(', ')} — notification ${notificationID} has ` +
+            'no stored value to restore. Pass the real value, or call listNotifications with includeSecrets ' +
+            'to read the current one.'
+          );
+        }
+
         const response = await client.addNotification(notification, notificationID);
+        let text = response.msg || `Notification ${notificationID} updated`;
+        if (preserved.length > 0) {
+          text += `\n\nKept the existing value for ${preserved.join(', ')} — "***" was sent, which is the redaction marker, not a credential.`;
+        }
         return {
-          content: [{ type: 'text', text: response.msg || `Notification ${notificationID} updated` }],
+          content: [{ type: 'text', text }],
           structuredContent: { ok: response.ok, id: response.id, msg: response.msg },
         };
       } catch (error) {
@@ -1090,17 +1217,22 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
     {
       title: 'List Docker Hosts',
       description: 'Returns all docker daemon connections configured in Uptime Kuma. These are referenced by docker container monitors via docker_host.',
-      inputSchema: {},
+      inputSchema: {
+        includeSecrets: includeSecretsParam
+      },
       outputSchema: {
-        dockerHosts: z.array(DockerHostSchema).describe('Array of docker host configurations'),
+        dockerHosts: z.array(DockerHostSchema).describe('Array of docker host configurations. Any credentials embedded in a dockerDaemon URL read "***" unless includeSecrets is set.'),
         count: z.number(),
       },
     },
-    async () => {
+    async ({ includeSecrets }) => {
       await authenticateClient();
 
       try {
-        const dockerHosts = client.getDockerHostList();
+        const raw = client.getDockerHostList();
+        // A TCP dockerDaemon can be http://user:pass@host:2375 — the field name gives no
+        // hint of that, so the URL scrub in redactSecrets is what catches it.
+        const dockerHosts = wantsSecrets(includeSecrets) ? raw : raw.map((h) => redactSecrets(h));
         return {
           content: [{ type: 'text', text: JSON.stringify(dockerHosts, null, 2) }],
           structuredContent: { dockerHosts, count: dockerHosts.length },

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -9,4 +9,10 @@ export interface UptimeKumaConfig {
   password: string | undefined;
   token: string | undefined;
   jwtToken: string | undefined;
+  /**
+   * Return notification and monitor credentials in full instead of "***" (issue #59).
+   * Optional and defaults to false, so an existing config object stays valid and the
+   * safe behaviour is the one you get by not thinking about it.
+   */
+  includeSecrets?: boolean;
 }

--- a/test/integration/monitors.test.ts
+++ b/test/integration/monitors.test.ts
@@ -321,8 +321,11 @@ export const monitorTests: Array<{ name: string; fn: TestFn }> = [
         if (!sc?.pushURL || !String(sc.pushURL).includes('/api/push/')) {
           throw new Error(`expected a ping URL, got ${JSON.stringify(sc?.pushURL)}`);
         }
+        // includeSecrets is required here (#59): pushToken reads "***" by default, and
+        // comparing what was stored against what was returned needs the real value. This is
+        // the canonical case for the opt-in — verifying a credential rather than listing it.
         const stored = JSON.parse(extractText(
-          await client.callTool({ name: 'getMonitor', arguments: { monitorID, includeTypeSpecificFields: true } }) as CallToolResult,
+          await client.callTool({ name: 'getMonitor', arguments: { monitorID, includeTypeSpecificFields: true, includeSecrets: true } }) as CallToolResult,
           'getMonitor'
         ));
         if (stored.pushToken !== sc.pushToken) throw new Error('stored push token does not match the returned one');

--- a/test/integration/redaction.test.ts
+++ b/test/integration/redaction.test.ts
@@ -1,0 +1,262 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { TestFn, extractText } from './helpers.js';
+
+/**
+ * Integration tests for credential redaction (issue #59).
+ *
+ * The unit tests cover the redactor in isolation; these prove the two things that can
+ * only be shown against a live server:
+ *
+ *   1. a secret written through the MCP does not come back out of the read tools, and
+ *   2. the read-edit-write loop an agent naturally performs does not replace that
+ *      secret with the redaction marker.
+ *
+ * Every object created here is deleted in a finally block.
+ */
+
+const MARKER = '***';
+const SMTP_PASSWORD = 'zz-integration-secret-do-not-use';
+const API_KEY = 'zz-integration-header-key';
+
+async function call(client: any, name: string, args: Record<string, unknown>): Promise<CallToolResult> {
+  return (await client.callTool({ name, arguments: args })) as CallToolResult;
+}
+
+export const redactionTests: Array<{ name: string; fn: TestFn }> = [
+  {
+    name: 'listNotifications withholds credentials and names what it withheld',
+    fn: async ({ client }) => {
+      let notificationID: number | undefined;
+      try {
+        const created = await call(client, 'addNotification', {
+          name: 'zz-redaction-delete-me',
+          type: 'smtp',
+          config: {
+            type: 'smtp',
+            smtpHost: 'smtp.example.invalid',
+            smtpPort: 587,
+            smtpUsername: 'zz-user',
+            smtpPassword: SMTP_PASSWORD,
+            smtpFrom: 'zz@example.invalid',
+            smtpTo: 'zz@example.invalid',
+          },
+        });
+        notificationID = (created as any).structuredContent?.id;
+        if (!notificationID) throw new Error('addNotification returned no id');
+
+        const listed = extractText(await call(client, 'listNotifications', {}), 'listNotifications');
+        if (listed.includes(SMTP_PASSWORD)) {
+          throw new Error('smtpPassword came back in cleartext');
+        }
+        if (!listed.includes(MARKER) && !listed.includes('redactedConfigKeys')) {
+          throw new Error('no sign the config was redacted at all');
+        }
+        if (!listed.includes('smtpPassword')) {
+          throw new Error('redactedConfigKeys should still NAME smtpPassword so the caller knows it is set');
+        }
+
+        const withSecrets = extractText(
+          await call(client, 'listNotifications', { includeSecrets: true }),
+          'listNotifications'
+        );
+        if (!withSecrets.includes(SMTP_PASSWORD)) {
+          throw new Error('includeSecrets: true did not return the real value');
+        }
+        console.log('  ✓ listNotifications redacts by default and opts in on request');
+      } finally {
+        if (notificationID) await call(client, 'deleteNotification', { notificationID });
+      }
+    },
+  },
+
+  {
+    name: 'updateNotification does not clobber a secret it never showed the caller',
+    fn: async ({ client }) => {
+      // This is the case the maintainer flagged on #59. addNotification REPLACES the row,
+      // so a caller that reads a redacted config, renames the channel and writes it back
+      // would persist "***" as the SMTP password.
+      let notificationID: number | undefined;
+      try {
+        const created = await call(client, 'addNotification', {
+          name: 'zz-clobber-delete-me',
+          type: 'smtp',
+          config: {
+            type: 'smtp',
+            smtpHost: 'smtp.example.invalid',
+            smtpPort: 587,
+            smtpUsername: 'zz-user',
+            smtpPassword: SMTP_PASSWORD,
+            smtpFrom: 'zz@example.invalid',
+            smtpTo: 'zz@example.invalid',
+          },
+        });
+        notificationID = (created as any).structuredContent?.id;
+        if (!notificationID) throw new Error('addNotification returned no id');
+
+        // Exactly what an agent would send after a redacted read.
+        await call(client, 'updateNotification', {
+          notificationID,
+          name: 'zz-clobber-delete-me-renamed',
+          type: 'smtp',
+          config: {
+            type: 'smtp',
+            smtpHost: 'smtp.example.invalid',
+            smtpPort: 587,
+            smtpUsername: 'zz-user',
+            smtpPassword: MARKER,
+            smtpFrom: 'zz@example.invalid',
+            smtpTo: 'zz@example.invalid',
+          },
+        });
+
+        const after = extractText(
+          await call(client, 'listNotifications', { includeSecrets: true }),
+          'listNotifications'
+        );
+        const row = JSON.parse(after).find((n: any) => n.id === notificationID);
+        if (!row) throw new Error('notification vanished after update');
+        const config = typeof row.config === 'string' ? JSON.parse(row.config) : row.config;
+
+        if (config.smtpPassword === MARKER) {
+          throw new Error('the redaction marker was written over the real password');
+        }
+        if (config.smtpPassword !== SMTP_PASSWORD) {
+          throw new Error(`password was not preserved (got ${JSON.stringify(config.smtpPassword)})`);
+        }
+        if (row.name !== 'zz-clobber-delete-me-renamed') {
+          throw new Error('the rename did not land');
+        }
+        console.log('  ✓ updateNotification preserved the password and applied the rename');
+      } finally {
+        if (notificationID) await call(client, 'deleteNotification', { notificationID });
+      }
+    },
+  },
+
+  {
+    name: 'listMonitors / getMonitor withhold headers and pushToken',
+    fn: async ({ client }) => {
+      let monitorID: number | undefined;
+      try {
+        const created = await call(client, 'createMonitor', {
+          name: 'zz-redaction-monitor-delete-me',
+          type: 'http',
+          url: 'https://example.invalid/health',
+          interval: 300,
+          active: false,
+          headers: JSON.stringify({ 'X-Api-Key': API_KEY }),
+        });
+        monitorID = (created as any).structuredContent?.monitorID;
+        if (!monitorID) throw new Error('createMonitor returned no monitorID');
+
+        const listed = extractText(
+          await call(client, 'listMonitors', { includeTypeSpecificFields: true }),
+          'listMonitors'
+        );
+        if (listed.includes(API_KEY)) throw new Error('an API key in headers came back in cleartext');
+
+        const one = extractText(
+          await call(client, 'getMonitor', { monitorID, includeTypeSpecificFields: true }),
+          'getMonitor'
+        );
+        if (one.includes(API_KEY)) throw new Error('getMonitor returned headers in cleartext');
+        if (!one.includes(MARKER)) throw new Error('getMonitor did not mark headers as withheld');
+
+        const withSecrets = extractText(
+          await call(client, 'getMonitor', { monitorID, includeTypeSpecificFields: true, includeSecrets: true }),
+          'getMonitor'
+        );
+        if (!withSecrets.includes(API_KEY)) throw new Error('includeSecrets: true did not return headers');
+        console.log('  ✓ monitor headers withheld by default, returned on opt-in');
+      } finally {
+        if (monitorID) await call(client, 'deleteMonitor', { monitorID });
+      }
+    },
+  },
+
+  {
+    name: 'updateMonitor does not clobber headers when the marker is sent back',
+    fn: async ({ client }) => {
+      let monitorID: number | undefined;
+      try {
+        const created = await call(client, 'createMonitor', {
+          name: 'zz-redaction-update-delete-me',
+          type: 'http',
+          url: 'https://example.invalid/health',
+          interval: 300,
+          active: false,
+          headers: JSON.stringify({ 'X-Api-Key': API_KEY }),
+        });
+        monitorID = (created as any).structuredContent?.monitorID;
+        if (!monitorID) throw new Error('createMonitor returned no monitorID');
+
+        await call(client, 'updateMonitor', {
+          monitorID,
+          name: 'zz-redaction-update-delete-me-renamed',
+          headers: MARKER,
+        });
+
+        const after = extractText(
+          await call(client, 'getMonitor', { monitorID, includeTypeSpecificFields: true, includeSecrets: true }),
+          'getMonitor'
+        );
+        const monitor = JSON.parse(after);
+        if (monitor.headers === MARKER) throw new Error('the marker was written over the real headers');
+        if (!String(monitor.headers).includes(API_KEY)) {
+          throw new Error(`headers were not preserved (got ${JSON.stringify(monitor.headers)})`);
+        }
+        if (monitor.name !== 'zz-redaction-update-delete-me-renamed') {
+          throw new Error('the rename did not land');
+        }
+        console.log('  ✓ updateMonitor preserved headers and applied the rename');
+      } finally {
+        if (monitorID) await call(client, 'deleteMonitor', { monitorID });
+      }
+    },
+  },
+
+  {
+    name: 'the marker is refused on create, where there is nothing to restore',
+    fn: async ({ client }) => {
+      // Cloning a channel or monitor read back redacted is the realistic way to reach this.
+      // Accepting it would persist "***" as a credential that looks set and cannot work.
+      let created: number | undefined;
+      try {
+        const result = await call(client, 'addNotification', {
+          name: 'zz-marker-on-create-delete-me',
+          type: 'smtp',
+          config: { type: 'smtp', smtpHost: 'smtp.example.invalid', smtpPassword: MARKER },
+        });
+        created = (result as any).structuredContent?.id;
+        if (!result.isError && created) {
+          throw new Error('addNotification accepted the redaction marker as a password');
+        }
+        const text = (result.content as any[])?.find((c: any) => c.type === 'text')?.text ?? '';
+        if (!String(text).includes('smtpPassword')) {
+          throw new Error(`error should name the offending field, got: ${text}`);
+        }
+        console.log('  ✓ addNotification refuses the marker and names the field');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (/accepted the redaction marker/.test(message)) throw err;
+        if (!message.includes('smtpPassword')) {
+          throw new Error(`error should name the offending field, got: ${message}`);
+        }
+        console.log('  ✓ addNotification refuses the marker and names the field');
+      } finally {
+        if (created) await call(client, 'deleteNotification', { notificationID: created });
+      }
+    },
+  },
+
+  {
+    name: 'getMonitorSummary stays free of credentials without needing redaction',
+    fn: async ({ client }) => {
+      const text = extractText(await call(client, 'getMonitorSummary', {}), 'getMonitorSummary');
+      for (const key of ['pushToken', 'basic_auth_pass', 'bearer_token', 'headers']) {
+        if (text.includes(key)) throw new Error(`getMonitorSummary unexpectedly returned ${key}`);
+      }
+      console.log('  ✓ getMonitorSummary remains the safe default it already was');
+    },
+  },
+];

--- a/test/integration/run-all.ts
+++ b/test/integration/run-all.ts
@@ -14,6 +14,7 @@ import { notificationTests } from './notifications.test.js';
 import { dockerHostTests } from './docker-hosts.test.js';
 import { statusPageTests } from './status-pages.test.js';
 import { strictSchemaTests } from './strict-schema.test.js';
+import { redactionTests } from './redaction.test.js';
 
 /**
  * Unified integration test runner.
@@ -37,6 +38,7 @@ const ALL_SUITES: Record<string, { name: string; tests: Array<{ name: string; fn
   'docker-hosts': { name: 'Docker Hosts', tests: dockerHostTests },
   'status-pages': { name: 'Status Pages', tests: statusPageTests },
   'strict-schema': { name: 'Strict Input Schemas', tests: strictSchemaTests },
+  redaction: { name: 'Credential Redaction', tests: redactionTests },
 };
 
 async function main() {

--- a/test/unit/redact.test.ts
+++ b/test/unit/redact.test.ts
@@ -7,6 +7,7 @@ import {
   redactNotification,
   redactNotifications,
   rehydrateSecrets,
+  rehydrateUrlCredentials,
 } from '../../src/redact.js';
 
 describe('redact - key classification', () => {
@@ -271,5 +272,65 @@ describe('rehydrateSecrets - the read-edit-write loop', () => {
 
     expect(shown.smtpPassword).toBe('super-secret');
     expect(shown.smtpHost).toBe('smtp2.example.com');
+  });
+});
+
+describe('rehydrateUrlCredentials - the dockerDaemon read-edit-write loop', () => {
+  // redactUrlCredentials scrubs user:pass to "***:***@host", which is NOT the bare "***"
+  // marker rehydrateSecrets matches. updateDockerHost writes the whole URL back, so this is
+  // the counterpart that keeps that path from clobbering the credential.
+  const stored = 'http://admin:s3cret@dockerd.local:2375';
+
+  it('restores both userinfo halves a redacted read scrubbed', () => {
+    const shown = redactUrlCredentials(stored); // http://***:***@dockerd.local:2375/
+    const { value, preserved, missing } = rehydrateUrlCredentials(shown, stored);
+
+    // URL serialization normalises an empty path to "/", the same normalisation
+    // redactUrlCredentials already applied on the way out — the credential is what matters.
+    expect(value).toBe('http://admin:s3cret@dockerd.local:2375/');
+    expect(preserved).toBe(true);
+    expect(missing).toBe(false);
+  });
+
+  it('restores credentials even when the caller changed the endpoint', () => {
+    // The realistic edit: read the redacted host, repoint it, write it back. The
+    // credentials must ride along to the new endpoint rather than being wiped.
+    const { value, preserved } = rehydrateUrlCredentials('http://***:***@new-host:2375', stored);
+    expect(value).toBe('http://admin:s3cret@new-host:2375/');
+    expect(preserved).toBe(true);
+  });
+
+  it('reports missing when there is no stored credential to restore', () => {
+    // A create, or a host that never had inline credentials. Writing "***" would save an
+    // endpoint that looks authenticated and cannot connect.
+    const withoutCreds = rehydrateUrlCredentials('http://***:***@new-host:2375', 'http://dockerd.local:2375');
+    expect(withoutCreds.missing).toBe(true);
+    expect(withoutCreds.preserved).toBe(false);
+
+    const noStored = rehydrateUrlCredentials('http://***:***@new-host:2375', undefined);
+    expect(noStored.missing).toBe(true);
+  });
+
+  it('leaves a URL without the marker untouched', () => {
+    const realEdit = 'http://newuser:newpass@dockerd.local:2375';
+    const { value, preserved, missing } = rehydrateUrlCredentials(realEdit, stored);
+    expect(value).toBe(realEdit);
+    expect(preserved).toBe(false);
+    expect(missing).toBe(false);
+  });
+
+  it('leaves non-URL values (a unix socket path) untouched', () => {
+    const socket = '/var/run/docker.sock';
+    expect(rehydrateUrlCredentials(socket, undefined)).toEqual({
+      value: socket,
+      preserved: false,
+      missing: false,
+    });
+  });
+
+  it('restores a password-only userinfo', () => {
+    const { value, preserved } = rehydrateUrlCredentials('http://:***@dockerd.local:2375', 'http://:s3cret@dockerd.local:2375');
+    expect(value).toBe('http://:s3cret@dockerd.local:2375/');
+    expect(preserved).toBe(true);
   });
 });

--- a/test/unit/redact.test.ts
+++ b/test/unit/redact.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SECRET_MARKER,
+  isSecretKey,
+  redactSecrets,
+  redactUrlCredentials,
+  redactNotification,
+  redactNotifications,
+  rehydrateSecrets,
+} from '../../src/redact.js';
+
+describe('redact - key classification', () => {
+  it('catches the fields named in issue #59', () => {
+    for (const key of [
+      'pushToken',
+      'push_token',
+      'basic_auth_pass',
+      'bearer_token',
+      'oauth_client_secret',
+      'radiusPassword',
+      'radiusSecret',
+      'mqttPassword',
+      'rabbitmqPassword',
+      'smtpPassword',
+      'ntfypassword',
+      'databaseConnectionString',
+      'headers',
+      'tlsCert',
+      'tlsKey',
+      'tlsCa',
+    ]) {
+      expect(isSecretKey(key), `${key} should be treated as secret`).toBe(true);
+    }
+  });
+
+  it('treats snake_case and camelCase spellings as the same field', () => {
+    expect(isSecretKey('push_token')).toBe(isSecretKey('pushToken'));
+    expect(isSecretKey('database_connection_string')).toBe(isSecretKey('databaseConnectionString'));
+    expect(isSecretKey('tls_key')).toBe(isSecretKey('tlsKey'));
+  });
+
+  it('catches unknown future fields via the pattern, not just the explicit list', () => {
+    for (const key of ['someNewApiKey', 'providerSecretValue', 'x_credential', 'privateKey', 'jwtSigningKey']) {
+      expect(isSecretKey(key), `${key} should be caught by the safety net`).toBe(true);
+    }
+  });
+
+  it('does not hide configuration that merely sounds sensitive', () => {
+    // The reason the `auth` alternative in the pattern is narrowed: these are useful,
+    // and a redaction that hides them is one people switch off.
+    for (const key of [
+      'oauth_token_url',
+      'authMethod',
+      'oauth_auth_method',
+      'oauth_scopes',
+      'oauth_audience',
+      'basic_auth_user',
+      'mqttUsername',
+      'radiusUsername',
+      'hostname',
+      'port',
+      'url',
+      'interval',
+      'includeSensitiveData',
+      'accepted_statuscodes',
+    ]) {
+      expect(isSecretKey(key), `${key} should stay visible`).toBe(false);
+    }
+  });
+});
+
+describe('redact - monitors', () => {
+  const monitor = {
+    id: 95,
+    name: 'Melchior Backup Heartbeat',
+    type: 'push',
+    hostname: 'melchior.local',
+    port: 8080,
+    pushToken: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6',
+    basic_auth_user: 'reader',
+    basic_auth_pass: 'hunter2',
+    headers: '{"X-Api-Key":"live-arr-key"}',
+    oauth_token_url: 'https://idp.example.com/token',
+    authMethod: 'oauth2-cc',
+  };
+
+  it('masks credentials and keeps everything else', () => {
+    const out = redactSecrets(monitor);
+    expect(out.pushToken).toBe(SECRET_MARKER);
+    expect(out.basic_auth_pass).toBe(SECRET_MARKER);
+    expect(out.headers).toBe(SECRET_MARKER);
+
+    expect(out.id).toBe(95);
+    expect(out.name).toBe('Melchior Backup Heartbeat');
+    expect(out.hostname).toBe('melchior.local');
+    expect(out.port).toBe(8080);
+    expect(out.basic_auth_user).toBe('reader');
+    expect(out.oauth_token_url).toBe('https://idp.example.com/token');
+    expect(out.authMethod).toBe('oauth2-cc');
+  });
+
+  it('does not mutate its input', () => {
+    // This is the property that keeps updateMonitor safe: it merges over the cached row,
+    // and the cached row is what redactSecrets was handed.
+    const before = JSON.stringify(monitor);
+    redactSecrets(monitor);
+    expect(JSON.stringify(monitor)).toBe(before);
+  });
+
+  it('leaves unset fields unset instead of claiming a credential exists', () => {
+    const out = redactSecrets({ pushToken: '', basic_auth_pass: null, bearer_token: undefined });
+    expect(out.pushToken).toBe('');
+    expect(out.basic_auth_pass).toBeNull();
+    expect(out.bearer_token).toBeUndefined();
+  });
+
+  it('descends into nested objects rather than masking them wholesale', () => {
+    // kafkaProducerSaslOptions is an object; masking it whole would hide the mechanism
+    // and break its own schema.
+    const out = redactSecrets({
+      kafkaProducerSaslOptions: { mechanism: 'scram-sha-256', username: 'kafka', password: 'swordfish' },
+    });
+    expect(out.kafkaProducerSaslOptions).toEqual({
+      mechanism: 'scram-sha-256',
+      username: 'kafka',
+      password: SECRET_MARKER,
+    });
+  });
+
+  it('strips inline credentials from URLs, which no field name reveals', () => {
+    expect(redactUrlCredentials('https://admin:s3cret@example.com/health')).toBe(
+      `https://${SECRET_MARKER}:${SECRET_MARKER}@example.com/health`
+    );
+    expect(redactUrlCredentials('https://example.com/health')).toBe('https://example.com/health');
+    expect(redactUrlCredentials('not a url')).toBe('not a url');
+  });
+
+  it('keeps rabbitmqNodes valid URLs after scrubbing', () => {
+    const out = redactSecrets({ rabbitmqNodes: ['http://guest:guest@rabbit:15672'] });
+    const [node] = out.rabbitmqNodes as string[];
+    expect(() => new URL(node)).not.toThrow();
+    expect(node).not.toContain('guest:guest');
+  });
+});
+
+describe('redact - notifications (allowlist)', () => {
+  const smtp = {
+    id: 2,
+    name: 'My Email Alert',
+    active: true,
+    isDefault: true,
+    config: JSON.stringify({
+      type: 'smtp',
+      smtpHost: 'email-smtp.ap-southeast-2.amazonaws.com',
+      smtpPort: 587,
+      smtpUsername: 'AKIAEXAMPLE',
+      smtpPassword: 'super-secret',
+      smtpFrom: 'alerts@example.com',
+    }),
+  };
+
+  it('withholds every config field outside the allowlist', () => {
+    const out = redactNotification(smtp);
+    const config = JSON.parse(out.config as string);
+
+    expect(config.type).toBe('smtp');
+    expect(config.smtpPassword).toBeUndefined();
+    expect(config.smtpUsername).toBeUndefined();
+    expect(JSON.stringify(out)).not.toContain('super-secret');
+    expect(JSON.stringify(out)).not.toContain('AKIAEXAMPLE');
+  });
+
+  it('names what it withheld, so a caller can see the field is set', () => {
+    const out = redactNotification(smtp);
+    expect(out.redactedConfigKeys).toEqual(
+      expect.arrayContaining(['smtpHost', 'smtpPort', 'smtpUsername', 'smtpPassword', 'smtpFrom'])
+    );
+  });
+
+  it('keeps the row columns needed to attach a channel to a monitor', () => {
+    // notificationIDList only ever needs the id — the credentials are incidental
+    // to every workflow in the issue.
+    const out = redactNotification(smtp);
+    expect(out.id).toBe(2);
+    expect(out.name).toBe('My Email Alert');
+    expect(out.active).toBe(true);
+    expect(out.isDefault).toBe(true);
+  });
+
+  it('withholds an unparseable config in full rather than guessing', () => {
+    const out = redactNotification({ id: 9, name: 'Broken', config: 'not json' });
+    expect(out.config).toBe(SECRET_MARKER);
+  });
+
+  it('preserves the config field shape (string in, string out)', () => {
+    expect(typeof redactNotification(smtp).config).toBe('string');
+    expect(typeof redactNotification({ id: 1, config: { type: 'slack', webhookURL: 'x' } }).config).toBe('object');
+  });
+
+  it('does not mutate the cached rows it is handed', () => {
+    // getNotificationList() returns references straight out of notificationListCache.
+    const before = JSON.stringify(smtp);
+    redactNotifications([smtp]);
+    expect(JSON.stringify(smtp)).toBe(before);
+  });
+});
+
+describe('rehydrateSecrets - the read-edit-write loop', () => {
+  it('restores a stored value when the marker is sent back', () => {
+    const incoming = { name: 'Renamed', smtpPassword: SECRET_MARKER };
+    const stored = { name: 'Original', smtpPassword: 'super-secret' };
+
+    const { preserved, missing } = rehydrateSecrets(incoming, stored);
+
+    expect(incoming.smtpPassword).toBe('super-secret');
+    expect(incoming.name).toBe('Renamed');
+    expect(preserved).toEqual(['smtpPassword']);
+    expect(missing).toEqual([]);
+  });
+
+  it('reports a marker with nothing behind it instead of writing it', () => {
+    const incoming = { pushToken: SECRET_MARKER };
+    const { preserved, missing } = rehydrateSecrets(incoming, { pushToken: '' });
+
+    expect(missing).toEqual(['pushToken']);
+    expect(preserved).toEqual([]);
+    // Left as-is for the caller to reject on; writing it would create a credential
+    // that looks set and cannot work.
+    expect(incoming.pushToken).toBe(SECRET_MARKER);
+  });
+
+  it('leaves real values alone', () => {
+    const incoming = { smtpPassword: 'a-new-password' };
+    const { preserved } = rehydrateSecrets(incoming, { smtpPassword: 'old' });
+    expect(incoming.smtpPassword).toBe('a-new-password');
+    expect(preserved).toEqual([]);
+  });
+
+  it('descends into nested objects and reports a dotted path', () => {
+    const incoming = { kafkaProducerSaslOptions: { mechanism: 'plain', password: SECRET_MARKER } };
+    const stored = { kafkaProducerSaslOptions: { mechanism: 'plain', password: 'swordfish' } };
+
+    const { preserved } = rehydrateSecrets(incoming, stored);
+
+    expect(incoming.kafkaProducerSaslOptions.password).toBe('swordfish');
+    expect(preserved).toEqual(['kafkaProducerSaslOptions.password']);
+  });
+
+  it('reports every marker as missing when there is no stored object (the create path)', () => {
+    // createMonitor / addNotification have nothing to restore from, so a marker there must
+    // be refused rather than saved as the credential.
+    const incoming = { name: 'Cloned', smtpPassword: SECRET_MARKER, smtpHost: 'smtp.example.com' };
+    const { preserved, missing } = rehydrateSecrets(incoming, undefined);
+
+    expect(missing).toEqual(['smtpPassword']);
+    expect(preserved).toEqual([]);
+    expect(incoming.smtpHost).toBe('smtp.example.com');
+  });
+
+  it('round-trips a redacted read without destroying the secret', () => {
+    // The whole point of the pairing: what redaction hands out must survive being
+    // handed straight back.
+    const stored = { type: 'smtp', smtpHost: 'smtp.example.com', smtpPassword: 'super-secret' };
+    const shown = JSON.parse(JSON.stringify(stored)) as Record<string, unknown>;
+    for (const k of Object.keys(shown)) {
+      if (isSecretKey(k)) shown[k] = SECRET_MARKER;
+    }
+
+    shown.smtpHost = 'smtp2.example.com';
+    rehydrateSecrets(shown, stored);
+
+    expect(shown.smtpPassword).toBe('super-secret');
+    expect(shown.smtpHost).toBe('smtp2.example.com');
+  });
+});


### PR DESCRIPTION
Closes #59.

Implements the design you laid out in https://github.com/DavidFuchs/mcp-uptime-kuma/issues/59#issuecomment-5153359031 — single opt-in, allowlist for notifications, denylist plus regex safety net for monitors — with the "don't clobber existing secrets" constraint treated as the load-bearing part.

## The two rules that make it safe

**Redaction happens at the tool output boundary, never in the client or the cache.** `updateMonitor` merges the caller's changes over the monitor it reads back, and `getNotificationList()` returns references straight out of `notificationListCache`. Redacting in either place would mean the next write persists `***` over a live credential. Every function in `src/redact.ts` returns a copy, and the write paths keep reading unredacted.

**A marker sent back in is restored, not written.** This is the sharper edge, and it is worse on notifications than on monitors: `addNotification` *replaces* the row rather than merging, so the read-edit-write loop an agent naturally performs — read the channel, rename it, write it back — would replace a working SMTP password with three asterisks and report success. `updateMonitor` / `updateNotification` now restore the stored value and report which fields they preserved. `createMonitor` / `addNotification` have nothing to restore from, so they refuse the marker rather than saving a credential that looks set and cannot work.

## What is withheld

| Tool | Approach |
|---|---|
| `listNotifications` | allowlist — `config` keeps `type`/`name`/`isDefault`/`applyExisting`; withheld field names are returned in `redactedConfigKeys` |
| `listMonitors`, `getMonitor` | denylist + regex |
| `listDockerHosts` | `user:password@` inside a `dockerDaemon` URL |
| `getSettings` | regex |
| `getMonitorSummary` | untouched — it returns no credentials and stays the safe default |

Opt in with `{ includeSecrets: true }` per call or `UPTIME_KUMA_INCLUDE_SECRETS=true` globally. The parameter wins in both directions, so a permissive deployment can still ask one call to redact.

## Three judgement calls I'd like your read on

**1. I narrowed your regex on the `auth` alternative.** A bare `/auth/` also matches `authMethod`, `oauth_auth_method` and `oauth_scopes`, which are useful configuration rather than credentials. I also had to add `oauth_token_url` to an explicit never-secret set — it matches `token` and is an endpoint. What I landed on:

```
/pass(word|wd|phrase)?|secret|token|apikey|api_key|auth(oriz|entic)|bearer|credential|private.?key|jwt/i
```

My reasoning is that hiding useful fields is how a redaction feature gets switched off, but you may want it broader — say the word and I'll widen it.

**2. `headers` is masked wholesale, and the pattern would never have caught it.** It is free-form and in practice holds API keys — on my instance a `json-query` monitor carries `{"X-Api-Key": "<live arr key>"}`. Masking it hides non-secret headers too. Being selective is impossible without parsing caller-defined JSON and guessing at key names, so I took the safe default; happy to revisit.

**3. I extended scope past the issue as filed**, because both are the same mechanism and cheap to cover:
- `listDockerHosts` — a TCP `dockerDaemon` can be `http://user:pass@host:2375`, and no field name reveals that. The URL scrub keeps the endpoint readable and leaves `rabbitmqNodes` entries valid URLs, which wholesale masking would not.
- `getSettings` — the handler `JSON.stringify`s Uptime Kuma's raw settings blob into the text content, so `steamAPIKey` leaks there even though `SettingsSchema` declares only a safe subset. Redacting `structuredContent` alone would not have caught it.

Say the word if you'd rather those went in a separate PR.

## Notes

- I did **not** touch `createMonitor`'s returned push URL, which embeds the token by design. It is the only way to ever obtain that token, and the description already warns it is a credential — but it is an inconsistency under a redact-by-default policy, so flagging it rather than deciding for you.
- `updateNotification` replacing rather than merging the row is a pre-existing bug with its own blast radius (a caller that omits a config field wipes it, redaction or not). Not fixed here; happy to raise it separately.
- Known trade-off, documented in the code: a credential whose real value is literally `***` cannot be set, because it is indistinguishable from the marker. Preferable to silently overwriting a working secret.

## Testing

- **22 unit tests** (`test/unit/redact.test.ts`) — key classification including the fields that must *stay* visible, copy-not-mutate on both read paths, nested descent for `kafkaProducerSaslOptions` (an object, so masking it wholesale would hide `mechanism` and break its own schema), URL scrubbing, and re-hydration including the create path.
- **6 integration tests** (`test/integration/redaction.test.ts`, wired into `run-all.ts` as the `redaction` suite) — the two clobber cases are the ones that matter: create a channel with a real password, write back what a redacted read would have shown, and assert the stored password survived.
- Full suite: **39 passed, 0 failed** against a v2.4.0 instance. One existing test needed `includeSecrets: true` — comparing a stored push token against the returned one is the canonical case for the opt-in, and I've commented it as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
