### PR TITLE
fix(test): load .env.test with override so ambient env vars cannot redirect the integration suite

### DIFF
--- a/test/integration/helpers.ts
+++ b/test/integration/helpers.ts
@@ -8,7 +8,14 @@ import { config as dotenvConfig } from 'dotenv';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-dotenvConfig({ path: join(__dirname, '.env.test') });
+// override: true is load-bearing. dotenv does NOT replace variables already present in the
+// environment, so on any machine that also has UPTIME_KUMA_URL / UPTIME_KUMA_JWT_TOKEN set for
+// a real instance -- which is the normal state for anyone actually running this MCP server --
+// the ambient values silently win over .env.test. This suite creates and deletes monitors, so
+// the failure mode is running destructive tests against whatever the developer's own client is
+// pointed at. run-tests.sh already assumes the opposite ("environment loaded from .env.test by
+// the test file itself"); this makes that true.
+dotenvConfig({ path: join(__dirname, '.env.test'), override: true });
 
 export interface TestConfig {
   url: string;


### PR DESCRIPTION
Follow-up to the note at the end of #69 — sending it separately as offered, since it's unrelated to that PR.

## The problem

`test/integration/helpers.ts` loads `.env.test` with `dotenv`, which **does not override variables already present in the environment**:

```ts
dotenvConfig({ path: join(__dirname, '.env.test') });
```

Anyone actually *running* this MCP server has `UPTIME_KUMA_URL` and `UPTIME_KUMA_JWT_TOKEN` set for a real instance — that's the normal state for a contributor, not an unusual one. Those ambient values silently win over `.env.test`.

The integration suite creates and deletes monitors. So the failure mode is running destructive tests against whatever the developer's own client is pointed at, with nothing in the output to indicate it.

I hit it as an `authInvalidToken` (my ambient token, the test URL — the two didn't match, so it failed loudly). Had both variables come from the same instance, it would simply have run.

## Measured

Same command, only this line differing:

```
ambient UPTIME_KUMA_URL : http://production.example:3001

suite resolves to       : http://production.example:3001   # before
suite resolves to       : http://192.168.0.58:3001         # after (.env.test)
```

## Why `override: true` is the right shape

`run-tests.sh` already assumes it — the call site is commented *"Run the tests (environment loaded from `.env.test` by the test file itself)"* — and it sets nothing inline, so this makes the script's own contract true rather than changing it. `.env.test` is the file the runner creates, documents, and prints back to the user; it should be the thing that decides.

One residual worth knowing about, not addressed here: variables *absent* from `.env.test` still fall through to the ambient environment. A `.env.test` with only `UPTIME_KUMA_URL` and `UPTIME_KUMA_JWT_TOKEN` will still pick up an ambient `UPTIME_KUMA_USERNAME`/`PASSWORD`. Harmless in practice since JWT takes precedence at login, but I can make the loader ignore ambient `UPTIME_KUMA_*` entirely if you'd prefer the stronger guarantee.

## Testing

Unit suite green (100/100). Integration suite green against a live Uptime Kuma 2.4.0 — and, with the fix, green *without* needing `env -u UPTIME_KUMA_JWT_TOKEN -u UPTIME_KUMA_URL` in front of it, which is what I'd been doing to work around this.

## Unrelated, spotted while here

`npm run test:integration:direct` points at `test/integration/integration.test.ts`, which doesn't exist — the suite is now per-domain files plus `run-all.ts`. `CONTRIBUTING.md` documents that script as the way to run against your own instance, so it's broken guidance for a new contributor. Not touched here; happy to send a one-liner if you want it (`tsx test/integration/run-all.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
