### PR TITLE
fix: redact credentials from the heartbeat read tools (#59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ What is withheld:
 | `listNotifications` | everything in `config` except `type`/`name`/`isDefault`/`applyExisting`. The withheld field names are listed in `redactedConfigKeys` |
 | `listMonitors`, `getMonitor` | `pushToken`, `basic_auth_pass`, `bearer_token`, `oauth_client_secret`, `radiusPassword`, `radiusSecret`, `mqttPassword`, `rabbitmqPassword`, `tlsCert`/`tlsKey`/`tlsCa`, `databaseConnectionString`, `headers`, `grpcMetadata`, plus anything matching `/pass|secret|token|apikey|auth(oriz\|entic)|bearer|credential|private.?key|jwt/i` |
 | `listDockerHosts` | `user:password@` inside a `dockerDaemon` URL |
+| `getHeartbeats`, `listHeartbeats` | any column Uptime Kuma returns beyond the declared heartbeat fields (e.g. `response`, which can carry a service's response body) is dropped, and `user:password@` inside a URL quoted in the status message is scrubbed |
 | `getSettings` | any secret-named field Uptime Kuma returns (e.g. `steamAPIKey`) |
 | `getMonitorSummary` | nothing — it returns no credentials to begin with |
 

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,3 +1,5 @@
+import { HeartbeatSchema } from './types/heartbeat.js';
+
 /**
  * Redaction of secrets on the way OUT of the read tools (issue #59).
  *
@@ -88,24 +90,23 @@ export function isSecretKey(key: string): boolean {
 }
 
 /**
- * Strips `user:password@` out of a URL while leaving the rest readable.
+ * Scrubs `scheme://user:pass@` credentials out of a string, whether the whole value is a
+ * URL or a URL quoted inside a larger message.
  *
- * A monitor `url`, a `dockerDaemon` TCP endpoint and every entry of `rabbitmqNodes`
- * can all carry inline credentials, and none of those field NAMES suggest a secret.
- * Replacing the whole value would hide the endpoint too — and would break
- * `rabbitmqNodes`, whose schema requires each entry to still be a valid URL.
+ * A monitor `url`, a `dockerDaemon` TCP endpoint and every entry of `rabbitmqNodes` carry
+ * inline credentials that no field NAME reveals, and a heartbeat `msg` can echo the
+ * monitor's own URL mid-sentence ("connect ETIMEDOUT to http://admin:s3cret@host"). One
+ * regex covers both: it masks the userinfo of every occurrence and leaves the scheme, host
+ * and surrounding text byte-for-byte intact, so the endpoint stays readable and a
+ * `rabbitmqNodes` entry stays a valid URL. Working on the raw string rather than parsing it
+ * also means a value that is not a clean URL still has its credentials scrubbed.
  */
+const URL_USERINFO = /([a-z][a-z0-9+.-]*:\/\/)([^/?#\s@]+)@/gi;
 export function redactUrlCredentials(value: string): string {
-  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return value;
-  try {
-    const url = new URL(value);
-    if (!url.username && !url.password) return value;
-    if (url.username) url.username = SECRET_MARKER;
-    if (url.password) url.password = SECRET_MARKER;
-    return url.toString();
-  } catch {
-    return value;
-  }
+  return value.replace(URL_USERINFO, (_match, scheme: string, userinfo: string) => {
+    const masked = userinfo.includes(':') ? `${SECRET_MARKER}:${SECRET_MARKER}` : SECRET_MARKER;
+    return `${scheme}${masked}@`;
+  });
 }
 
 /**
@@ -138,6 +139,35 @@ export function redactSecrets<T>(value: T, keyHint?: string): T {
     }
   }
   return out as unknown as T;
+}
+
+/**
+ * The heartbeat's declared fields, and the allowlist its output is projected onto.
+ * Derived from the schema so the two cannot drift apart.
+ */
+const HEARTBEAT_FIELDS: ReadonlySet<string> = new Set(Object.keys(HeartbeatSchema.shape));
+
+/**
+ * Redacts one heartbeat on the way out of the read tools (issue #59, finding #3).
+ *
+ * A heartbeat is a STATUS record, but `HeartbeatSchema` used to `.passthrough()`, so any
+ * undeclared column Uptime Kuma sends — `response` most of all, which carries the monitored
+ * service's own response body — reached the tool surface untouched. `redactSecrets` cannot
+ * help there: `response` is not a secret-NAMED field and its body is arbitrary content, not a
+ * `user:pass@` URL. So this first PROJECTS the heartbeat onto its declared fields, dropping
+ * `response` and anything else passthrough used to admit, then runs `redactSecrets` over what
+ * survives to scrub a credential the `msg` may quote as a URL.
+ *
+ * The projection has to happen on the DATA, not just the schema: the tools stringify the object
+ * into their text block, which no output schema touches.
+ */
+export function redactHeartbeat<T>(heartbeat: T): T {
+  const source = heartbeat as Record<string, unknown>;
+  const projected: Record<string, unknown> = {};
+  for (const key of Object.keys(source)) {
+    if (HEARTBEAT_FIELDS.has(key)) projected[key] = source[key];
+  }
+  return redactSecrets(projected) as T;
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { HeartbeatSchema, MonitorBaseSchema, MonitorSummarySchema, SettingsSchem
 import type { UptimeKumaConfig } from './types/index.js';
 import {
   INCLUDE_SECRETS_DESCRIPTION,
+  redactHeartbeat,
   redactNotifications,
   redactSecrets,
   rehydrateSecrets,
@@ -460,10 +461,11 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
     'getHeartbeats',
     {
       title: 'Get Heartbeats',
-      description: 'Retrieves historical heartbeat data for a specific monitor (response times, status changes over time). Use this for analyzing patterns or history for one monitor. By default returns only the most recent heartbeat; set maxHeartbeats (up to 100) for historical analysis. Keep maxHeartbeats ≤10 unless user requests more.',
+      description: 'Retrieves historical heartbeat data for a specific monitor (response times, status changes over time). Use this for analyzing patterns or history for one monitor. By default returns only the most recent heartbeat; set maxHeartbeats (up to 100) for historical analysis. Keep maxHeartbeats ≤10 unless user requests more. Credentials embedded in a status message URL (user:pass@host) read "***" unless includeSecrets is set.',
       inputSchema: {
         monitorID: z.coerce.number().int().nonnegative().describe('The ID of the monitor to get heartbeats for'),
-        maxHeartbeats: z.coerce.number().int().positive().max(100).optional().describe('If set, returns the most recent X heartbeats (up to 100). If unset, returns only the most recent heartbeat (default: 1)')
+        maxHeartbeats: z.coerce.number().int().positive().max(100).optional().describe('If set, returns the most recent X heartbeats (up to 100). If unset, returns only the most recent heartbeat (default: 1)'),
+        includeSecrets: includeSecretsParam
       },
       outputSchema: { 
         monitorID: z.number(),
@@ -471,12 +473,15 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         count: z.number()
       },
     },
-    async ({ monitorID, maxHeartbeats }) => {
+    async ({ monitorID, maxHeartbeats, includeSecrets }) => {
       await authenticateClient();
 
       try {
         const count = maxHeartbeats ?? 1;
-        const heartbeatsArray = client.getHeartbeatsForMonitor(monitorID, count);
+        const raw = client.getHeartbeatsForMonitor(monitorID, count);
+        // Heartbeats are projected to their declared fields (dropping passthrough columns
+        // like response) and a msg that quotes the monitor's URL has its credentials scrubbed.
+        const heartbeatsArray = wantsSecrets(includeSecrets) ? raw : raw.map((hb) => redactHeartbeat(hb));
         
         return {
           content: [{ 
@@ -546,9 +551,10 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
     'listHeartbeats',
     {
       title: 'List Heartbeats',
-      description: 'Retrieves historical heartbeat data for ALL monitors (response times, status changes over time). Use this for analyzing patterns across multiple monitors or correlating events. By default returns only the most recent heartbeat per monitor; set maxHeartbeats (up to 100) for historical analysis. Keep maxHeartbeats ≤5 unless user requests more.',
+      description: 'Retrieves historical heartbeat data for ALL monitors (response times, status changes over time). Use this for analyzing patterns across multiple monitors or correlating events. By default returns only the most recent heartbeat per monitor; set maxHeartbeats (up to 100) for historical analysis. Keep maxHeartbeats ≤5 unless user requests more. Credentials embedded in a status message URL (user:pass@host) read "***" unless includeSecrets is set.',
       inputSchema: {
-        maxHeartbeats: z.coerce.number().int().positive().max(100).optional().describe('If set, returns the most recent X heartbeats per monitor (up to 100). If unset, returns only the most recent heartbeat per monitor (default: 1)')
+        maxHeartbeats: z.coerce.number().int().positive().max(100).optional().describe('If set, returns the most recent X heartbeats per monitor (up to 100). If unset, returns only the most recent heartbeat per monitor (default: 1)'),
+        includeSecrets: includeSecretsParam
       },
       outputSchema: { 
         heartbeats: z.record(z.string(), z.array(HeartbeatSchema)).describe('Map of monitor IDs to their heartbeat arrays'),
@@ -556,12 +562,19 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         totalHeartbeatCount: z.number()
       },
     },
-    async ({ maxHeartbeats }) => {
+    async ({ maxHeartbeats, includeSecrets }) => {
       await authenticateClient();
 
       try {
         const count = maxHeartbeats ?? 1;
-        const heartbeatList = client.getHeartbeatList(count);
+        const raw = client.getHeartbeatList(count);
+        // Heartbeats are projected to their declared fields (dropping passthrough columns
+        // like response) and a msg that quotes the monitor's URL has its credentials scrubbed.
+        const heartbeatList = wantsSecrets(includeSecrets)
+          ? raw
+          : Object.fromEntries(
+              Object.entries(raw).map(([id, beats]) => [id, beats.map((hb) => redactHeartbeat(hb))])
+            );
         
         // Calculate total heartbeat count
         const totalCount = Object.values(heartbeatList).reduce(

--- a/src/types/heartbeat.ts
+++ b/src/types/heartbeat.ts
@@ -20,7 +20,7 @@ export const HeartbeatSchema = z.object({
   monitorID: z.number().optional().describe('Monitor ID (camelCase)'),
   localDateTime: z.string().optional().describe('Local formatted time'),
   timezone: z.string().optional().describe('Server timezone'),
-}).passthrough();
+});
 
 /**
  * Heartbeat type inferred from the Zod schema

--- a/test/unit/redact.test.ts
+++ b/test/unit/redact.test.ts
@@ -4,6 +4,7 @@ import {
   isSecretKey,
   redactSecrets,
   redactUrlCredentials,
+  redactHeartbeat,
   redactNotification,
   redactNotifications,
   rehydrateSecrets,
@@ -332,5 +333,83 @@ describe('rehydrateUrlCredentials - the dockerDaemon read-edit-write loop', () =
     const { value, preserved } = rehydrateUrlCredentials('http://:***@dockerd.local:2375', 'http://:s3cret@dockerd.local:2375');
     expect(value).toBe('http://:s3cret@dockerd.local:2375/');
     expect(preserved).toBe(true);
+  });
+});
+
+describe('redactUrlCredentials - credentials quoted inside free text', () => {
+  it('masks user:pass embedded mid-message', () => {
+    const msg = 'connect ETIMEDOUT to http://admin:s3cret@dockerd.local:2375 after 10s';
+    expect(redactUrlCredentials(msg)).toBe(
+      'connect ETIMEDOUT to http://***:***@dockerd.local:2375 after 10s'
+    );
+  });
+
+  it('masks a username-only userinfo', () => {
+    expect(redactUrlCredentials('fetching https://token@api.example.com/v1')).toBe(
+      'fetching https://***@api.example.com/v1'
+    );
+  });
+
+  it('masks every occurrence in one string', () => {
+    const msg = 'primary http://a:b@one.local failed, retry http://c:d@two.local';
+    expect(redactUrlCredentials(msg)).toBe(
+      'primary http://***:***@one.local failed, retry http://***:***@two.local'
+    );
+  });
+
+  it('leaves a URL with no userinfo untouched', () => {
+    const msg = 'GET https://status.example.com/health returned 200';
+    expect(redactUrlCredentials(msg)).toBe(msg);
+  });
+
+  it('leaves text with no URL untouched', () => {
+    const msg = 'Request failed with status code 401';
+    expect(redactUrlCredentials(msg)).toBe(msg);
+  });
+});
+
+describe('redactHeartbeat - the read-tool boundary for heartbeats', () => {
+  it('scrubs credentials quoted in the status message', () => {
+    const beat = {
+      status: 0,
+      time: '2026-08-02 10:00:00',
+      msg: 'connect ECONNREFUSED http://admin:s3cret@internal.local:8080',
+      ping: null,
+    };
+    const out = redactHeartbeat(beat);
+    expect(out.msg).toBe('connect ECONNREFUSED http://***:***@internal.local:8080');
+    // Declared fields are kept.
+    expect(out.status).toBe(0);
+    expect(out.time).toBe('2026-08-02 10:00:00');
+  });
+
+  it('drops a passed-through response column rather than surfacing its body', () => {
+    const out = redactHeartbeat({
+      status: 1,
+      time: '2026-08-02 10:00:00',
+      msg: '200 - OK',
+      response: '{"access_token":"abc123","refresh_token":"def456"}',
+    });
+    expect(out).not.toHaveProperty('response');
+    expect(out.msg).toBe('200 - OK');
+  });
+
+  it('drops any undeclared column, including a secret-named one', () => {
+    const out = redactHeartbeat({
+      status: 1,
+      time: '2026-08-02 10:00:00',
+      msg: 'OK',
+      authToken: 'abc123',
+      internalDebugField: 'whatever',
+    });
+    expect(out).not.toHaveProperty('authToken');
+    expect(out).not.toHaveProperty('internalDebugField');
+  });
+
+  it('keeps declared fields, and returns a copy', () => {
+    const beat = { status: 1, time: '2026-08-02 10:00:00', msg: '200 - OK', ping: 42 };
+    const out = redactHeartbeat(beat);
+    expect(out).toEqual(beat);
+    expect(out).not.toBe(beat);
   });
 });


### PR DESCRIPTION
Closes the heartbeat half of the #59 credential-redaction work. `getHeartbeats` and `listHeartbeats` were returning heartbeats verbatim, so two things reached the tool surface that should not.

## What leaked

- `HeartbeatSchema` used `.passthrough()`, so any undeclared column Uptime Kuma sends came through. The one that matters is `response`, which can carry the monitored service's own response body (tokens, cookies, PII).
- A status `msg` can quote the monitor's own URL, credentials and all (an error echoing `http://user:pass@host`).

## The fix

Both are closed at the tool boundary, the same place and doctrine as #74 (allowlist projection, redact on a copy, never in the client or cache):

- **`redactHeartbeat`** projects each heartbeat onto its **declared** fields. The allowlist is derived from `HeartbeatSchema.shape` so the two cannot drift. It drops `response` and anything else passthrough admitted, then runs `redactSecrets` over what survives.
- The projection happens on the **data**, not just the schema. The tools stringify the object into their text block, which no output schema touches, so tightening the schema alone would not have closed that channel.
- **`.passthrough()` dropped** from `HeartbeatSchema` as defense-in-depth on the structured channel.
- While here, `redactSecrets`' URL-credential scrubbing is **unified**. One regex now masks `scheme://user:pass@` userinfo whether the whole value is a URL or a URL quoted mid-message, replacing the previous WHATWG whole-value pass. This removes the duplication and makes redaction strictly more thorough. `rehydrateUrlCredentials` (the `updateDockerHost` restore path) is unchanged and still round-trips.

Opt out with `includeSecrets: true` per call or `UPTIME_KUMA_INCLUDE_SECRETS=true` globally, consistent with the other read tools.

## Behavior change

Undeclared columns Uptime Kuma sends no longer appear in heartbeat output. For a status record the declared set is complete, and this is the allowlist-at-the-boundary stance already applied to monitors and notifications.

## Tests

Full unit suite passes (137). Added coverage that `response` is dropped rather than surfaced, that undeclared and secret-named columns don't survive the projection, and that a credential quoted in `msg` is still scrubbed, plus embedded-URL cases for the unified scrubber.