### PR TITLE
fix: keep the heartbeat status message off the MCP logging channel (#59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,11 @@ URL: a `http://***:***@host:2375` read back from `listDockerHosts` has its useri
 from the stored URL rather than persisted verbatim, so repointing a host without re-entering
 its credentials does not wipe them.
 
+The MCP logging channel gets the same rule. The debug log for a live heartbeat reports the
+monitored service's status message by length only (`msgLength=...`), never its content, since
+that message can echo a target URL with an embedded `user:password@` or a slice of a response
+body, and on the stdio transport those log notifications reach the client.
+
 ## LibreChat Configuration
 
 **stdio transport:**

--- a/src/uptime-kuma-client.ts
+++ b/src/uptime-kuma-client.ts
@@ -433,7 +433,13 @@ export class UptimeKumaClient {
       }
       
       const monitorID = heartbeat.monitorID.toString();
-      this.safeLog('debug', `Received heartbeat for monitor ${monitorID}: status=${heartbeat.status}, msg="${heartbeat.msg || ''}", ping=${heartbeat.ping || 'N/A'}ms`);
+      // The heartbeat msg is the monitored service's own status text. For HTTP monitors it can
+      // echo the target URL (including any user:password@ in it) or a slice of the response body,
+      // so logging it verbatim would push that onto the MCP logging channel, which on the stdio
+      // transport reaches the client. Report only its shape (length), never its content, the same
+      // rule #71 applies everywhere else a credential could surface.
+      const msgLength = (heartbeat.msg || '').length;
+      this.safeLog('debug', `Received heartbeat for monitor ${monitorID}: status=${heartbeat.status}, msgLength=${msgLength}, ping=${heartbeat.ping || 'N/A'}ms`);
       
       // Initialize array for this monitor if it doesn't exist
       if (!this.heartbeatListCache[monitorID]) {

--- a/test/unit/heartbeats.test.ts
+++ b/test/unit/heartbeats.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { UptimeKumaClient } from '../../src/uptime-kuma-client.js';
-import { injectHeartbeatListCache } from './helpers.js';
+import { injectHeartbeatListCache, createMockSocket, injectSocket } from './helpers.js';
 
 describe('UptimeKumaClient - Heartbeat Operations', () => {
   let client: UptimeKumaClient;
@@ -85,6 +85,35 @@ describe('UptimeKumaClient - Heartbeat Operations', () => {
 
       const result = client.getHeartbeatsForMonitor(5, 2);
       expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('heartbeat debug log - the MCP logging channel boundary', () => {
+    // The live 'heartbeat' listener logs at debug level, and on the stdio transport that
+    // notification reaches the client. The monitored service's msg can carry a URL with
+    // embedded credentials or a slice of a response body, so the log must report the msg
+    // shape (its length) and never its content.
+    it('logs the msg length, never the msg content', () => {
+      const logged: string[] = [];
+      const server = {
+        sendLoggingMessage: async ({ data }: { level: string; data: unknown }) => {
+          logged.push(String(data));
+        },
+      };
+      const loggingClient = new UptimeKumaClient('http://localhost:3001', server, () => true);
+
+      const { socket, onHandlers } = createMockSocket();
+      injectSocket(loggingClient, socket);
+      (loggingClient as unknown as { setupHeartbeatListeners: () => void }).setupHeartbeatListeners();
+
+      const secretMsg = 'GET https://admin:hunter2@internal.example.com/health failed';
+      onHandlers['heartbeat']({ monitorID: 7, status: 0, msg: secretMsg, ping: 42, time: '2024-01-01' });
+
+      const heartbeatLog = logged.find((line) => line.includes('Received heartbeat for monitor 7'));
+      expect(heartbeatLog).toBeDefined();
+      expect(heartbeatLog).not.toContain('hunter2');
+      expect(heartbeatLog).not.toContain(secretMsg);
+      expect(heartbeatLog).toContain(`msgLength=${secretMsg.length}`);
     });
   });
 });


### PR DESCRIPTION
## What this fixes

The live `heartbeat` listener logged the monitored service's status message verbatim at debug level:

```
Received heartbeat for monitor 7: status=0, msg="GET https://admin:hunter2@internal.example.com/health failed", ping=42ms
```

That `msg` is the monitored service's own text. For an HTTP monitor it can echo the target URL (including any `user:password@` in it) or a slice of the response body. On the stdio transport, log notifications reach the client, so this pushed onto the logging channel exactly the kind of content the read-tool boundary was hardened to withhold in #78. It is defence in depth rather than an exploited leak, but it is the same shape-only rule the codebase already states in #71: only a credential's shape is ever reported, never its value.

## The change

Log the message shape (its length) instead of its content:

```
Received heartbeat for monitor 7: status=0, msgLength=61, ping=42ms
```

`status` and `ping` stay, since neither carries service-supplied text. That keeps the debug signal (a beat arrived, roughly how big its message was) without putting the message itself on the wire.

I looked at the other logging sites while I was in there. The re-authentication logs report Uptime Kuma's own `response.msg` (for example `authInvalidToken`), not a submitted credential, and `authenticateClient` already routes through `describeCredential()`, which reports the JWT's segment count and length rather than its value. Both are already on the shape-only rule, so this PR is scoped to the one site that logged content.

## Test

Adds a unit test that drives the heartbeat listener with a message containing an embedded credential and asserts the emitted log line carries `msgLength=...` and neither the credential nor the raw message.

Full suite: 138 unit tests pass, build clean.
