### PR TITLE
fix: shut down the stdio server when its client disconnects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,9 +88,27 @@ Examples:
 // Run with the stdio transport
 async function runStdio(config: UptimeKumaConfig) {
   try {
-    const { server, authenticateClient } = await createServer(config);
+    const { server, client, authenticateClient } = await createServer(config);
     const transport = new StdioServerTransport();
-    
+
+    // Shut down cleanly when the client goes away. The socket.io connection to Uptime Kuma
+    // keeps Node's event loop alive, so without this the process lingers forever once the
+    // client disconnects. Spawned over stdio that orphaned process also holds the parent's
+    // pipe open, which is what makes a wrapping command appear to hang after its work is done.
+    // The client closing our stdin is the reliable signal here: a wrapper like npx can be
+    // killed without its children, but stdin EOF still reaches us.
+    let shuttingDown = false;
+    const shutdown = (code = 0) => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      try { client.disconnect(); } catch { /* best effort on the way out */ }
+      process.exit(code);
+    };
+    process.stdin.on('end', () => shutdown());
+    process.stdin.on('close', () => shutdown());
+    process.on('SIGINT', () => shutdown());
+    process.on('SIGTERM', () => shutdown());
+
     await server.connect(transport);
 
     // Now authenticate after transport is connected so we can log properly.


### PR DESCRIPTION
## What this fixes

The stdio server never exited once the MCP client disconnected. The socket.io connection to Uptime Kuma keeps Node's event loop alive, so nothing brought the process down when the client went away, and it lingered indefinitely.

Spawned over stdio (an integration run, or an MCP client like VS Code or Claude Desktop), that orphaned process also held the parent's pipe open. That is what made a wrapping command look hung: the work finished, output stopped, but the shell never got its prompt back because a child was still holding the terminal.

It showed up most clearly in the integration runner. All 39 tests passed and it printed its summary, but the command never returned. Listing processes showed the runner had already exited while the spawned server (`src/index.ts -t stdio`) was still alive with its Uptime Kuma socket open.

## The change

In `runStdio`, shut down cleanly when the client goes away:

- Listen for stdin `end`/`close`. That is the reliable signal here: a wrapper such as `npx` can be killed without its children on Windows, but stdin EOF still reaches the server.
- Also handle `SIGINT` and `SIGTERM`.
- On any of those, disconnect the socket.io client and exit.

A guard makes the shutdown idempotent so overlapping signals don't double-run it.

## Verified

- `npm run build` clean.
- Full integration suite re-run: 39/39 pass and the command now returns on its own with exit code 0.
- No orphaned `node` processes remain after the run (confirmed before the fix there were three, after the fix there are none).

Only the stdio path changed; the streamable HTTP transport is untouched.
