### PR TITLE
feat: authenticate and Origin-validate the streamable HTTP transport (#62)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,11 @@ ENV UPTIME_KUMA_USERNAME=""
 ENV UPTIME_KUMA_PASSWORD=""
 ENV UPTIME_KUMA_2FA_TOKEN=""
 ENV UPTIME_KUMA_JWT_TOKEN=""
+# Guards for the streamable HTTP transport. Both are permissive by default; the server
+# warns at startup when it is left unprotected. See "Securing the HTTP Endpoint" in README.
+ENV MCP_AUTH_TOKEN=""
 ENV ALLOWED_ORIGIN="*"
+ENV HOST="0.0.0.0"
 ENV PORT=3000
 
 # Expose port for HTTP transport

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Then configure your MCP client to connect to the endpoint:
 
 See [Authentication Methods](#authentication-methods) for JWT token and anonymous authentication options.
 
+> **The endpoint above is unauthenticated.** Anyone who can reach port 3000 gets full
+> read/write control of your Uptime Kuma instance. See
+> [Securing the HTTP Endpoint](#securing-the-http-endpoint) before exposing it beyond localhost.
+
 ## Example Conversation
 
 ![MCP server answering questions about Uptime Kuma monitors](.github/images/screenshot-1.png)
@@ -190,6 +194,76 @@ docker run --rm davidfuchs/mcp-uptime-kuma:latest get-jwt http://host.docker.int
 ```
 
 **From browser:** Open Developer Tools → Storage/Application → Local Storage → find `token` key.
+
+## Securing the HTTP Endpoint
+
+Applies to `-t streamable-http` only. The stdio transport has no listener to protect and
+takes its credentials from the environment, as the MCP specification prescribes.
+
+Anyone who can reach `/mcp` has full read/write control of your Uptime Kuma instance,
+including deleting monitors. Two settings guard it, and both default to permissive so that
+upgrading cannot break an existing deployment — the server warns at startup in that state.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `MCP_AUTH_TOKEN` | unset (no authentication) | Shared secret that callers must present as `Authorization: Bearer <token>`. Anything else gets `401`. |
+| `ALLOWED_ORIGIN` | `*` (no validation) | Comma-separated list of browser origins permitted to call `/mcp`. A request whose `Origin` is not listed gets `403`. Requests with no `Origin` header — every native MCP client — are always allowed. |
+| `HOST` | `0.0.0.0` | Address to bind. Set to `127.0.0.1` when running locally outside a container. |
+| `PORT` | `3000` | Port to listen on. |
+
+`/health` is deliberately left unauthenticated so container healthchecks and load balancer
+probes keep working. It reports nothing but liveness.
+
+### Setting a token
+
+Generate a high-entropy secret — this is a password, and it is compared in constant time,
+so length is the only thing protecting it:
+
+```bash
+openssl rand -base64 32
+```
+
+```bash
+docker run -d \
+  --name mcp-uptime-kuma \
+  -p 3000:3000 \
+  -e UPTIME_KUMA_URL=http://your-uptime-kuma-instance:3001 \
+  -e UPTIME_KUMA_JWT_TOKEN=your_jwt_token \
+  -e MCP_AUTH_TOKEN=your_generated_secret \
+  davidfuchs/mcp-uptime-kuma:latest \
+  -t streamable-http
+```
+
+Clients then send it as a header:
+
+```json
+{
+  "mcpServers": {
+    "uptime-kuma": {
+      "url": "http://localhost:3000/mcp",
+      "headers": {
+        "Authorization": "Bearer your_generated_secret"
+      }
+    }
+  }
+}
+```
+
+### Why `Origin` validation matters separately
+
+A shared secret stops anyone who cannot present it. It does not stop a website your browser
+already trusts. Under a DNS rebinding attack a page on `evil.example` resolves its own
+hostname to `127.0.0.1`, so the browser treats requests to your local server as same-origin
+— no preflight happens and CORS never applies. The server comparing the `Origin` header it
+was sent against a list of expected origins is the only check left standing, which is why
+the MCP specification makes it a MUST rather than a SHOULD.
+
+If you only use native clients, leaving `ALLOWED_ORIGIN` unset costs you nothing; those
+clients send no `Origin` header. If you use a browser-based client, list its origin:
+
+```
+ALLOWED_ORIGIN=https://librechat.example.com,http://localhost:5173
+```
 
 ## Credential Redaction
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,12 @@ services:
 #      - UPTIME_KUMA_PASSWORD=${UPTIME_KUMA_PASSWORD} # Optional, if using username/password authentication
 #      - UPTIME_KUMA_JWT_TOKEN=${UPTIME_KUMA_JWT_TOKEN} # Optional, if using JWT authentication
 #      - PORT=3000 # Internal port. This is optional, defaults to 3000
+      # Strongly recommended: without MCP_AUTH_TOKEN anyone who can reach this port has full
+      # read/write control of your Uptime Kuma instance. Generate one with: openssl rand -base64 32
+#      - MCP_AUTH_TOKEN=${MCP_AUTH_TOKEN} # Clients must send 'Authorization: Bearer <token>'
+      # Only needed for browser-based MCP clients; native clients send no Origin header.
+      # Defaults to '*', which performs no Origin validation.
+#      - ALLOWED_ORIGIN=https://your-browser-client.example.com
     ports:
       - "3000:3000"
     # Override default CMD to use streamable HTTP transport instead of stdio

--- a/src/http-security.ts
+++ b/src/http-security.ts
@@ -1,0 +1,132 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type { RequestHandler } from 'express';
+
+/**
+ * Gating of requests on the way IN to the streamable HTTP transport (issue #62).
+ *
+ * Nothing here applies to stdio. The MCP spec is explicit that a stdio server takes its
+ * credentials from the environment and should not implement transport authorization —
+ * there is no network listener to protect. Everything below exists only because
+ * `-t streamable-http` opens a port.
+ *
+ * The spec's Streamable HTTP security warning names three protections, and the two we
+ * can implement here pull in opposite directions, which is why both exist:
+ *
+ * 1. VALIDATING `Origin` IS THE MUST, AND CORS IS NOT IT. The `cors` middleware only
+ *    sets response headers telling a browser whether the calling page may READ the
+ *    reply; the request has already run by then. That distinction is academic for a
+ *    read-only server and decisive for this one, whose tool surface includes
+ *    `deleteMonitor` and `deleteNotification`. It matters most in the attack the spec
+ *    actually names: under DNS rebinding the browser believes the request is
+ *    same-origin, so no preflight and no `Access-Control-*` check happens at all. The
+ *    only thing left that can notice is the server comparing the `Origin` header it was
+ *    sent against the origins it expects.
+ *
+ * 2. AUTHENTICATION IS THE SHOULD, AND IT DEFENDS A DIFFERENT ATTACKER. An Origin check
+ *    is worth nothing against a caller that is not a browser and simply omits the
+ *    header — which is every native MCP client, and therefore also every attacker who
+ *    can reach the port directly.
+ *
+ * Both default to permissive so that upgrading does not silently break a working
+ * deployment; `index.ts` warns loudly at startup in that state.
+ */
+
+/**
+ * `*` means "no Origin restriction". An allowlist is held normalised (see
+ * `normaliseOrigin`) so that comparison at request time is a plain equality check —
+ * substring or suffix matching is how `https://evil-example.com` ends up passing a check
+ * meant for `https://example.com`.
+ */
+export type AllowedOrigins = '*' | string[];
+
+/**
+ * An origin is `scheme://host[:port]` with no path, so lowercasing the whole string is
+ * equivalent to the case-insensitive scheme/host comparison RFC 6454 calls for, and
+ * cannot smudge a path the way it would on a full URL. The port is left significant:
+ * `http://localhost:3000` and `http://localhost:4000` are different origins.
+ */
+const normaliseOrigin = (origin: string): string => origin.trim().toLowerCase().replace(/\/$/, '');
+
+/**
+ * Reads the `ALLOWED_ORIGIN` setting. Unset, blank, or `*` all mean the wildcard: this
+ * is the pre-existing default and changing it would break browser-based clients of
+ * deployments that never opted in.
+ */
+export function parseAllowedOrigins(value: string | undefined): AllowedOrigins {
+  const raw = value?.trim();
+  if (!raw || raw === '*') {
+    return '*';
+  }
+
+  return raw
+    .split(',')
+    .map(normaliseOrigin)
+    .filter((origin) => origin.length > 0);
+}
+
+/**
+ * Rejects a cross-origin caller before it reaches the MCP handler.
+ *
+ * A request with NO `Origin` header is allowed through. That is not a loophole being
+ * left open, it is the common case: native clients (Claude Code, Claude Desktop, Cursor,
+ * VS Code) are not browsers and never send one. This check exists to constrain browsers,
+ * which always send it, and which are the only agent DNS rebinding can weaponise.
+ */
+export function createOriginMiddleware(allowed: AllowedOrigins): RequestHandler {
+  return (req, res, next) => {
+    const origin = req.headers.origin;
+
+    if (typeof origin !== 'string' || allowed === '*') {
+      next();
+      return;
+    }
+
+    if (allowed.includes(normaliseOrigin(origin))) {
+      next();
+      return;
+    }
+
+    // The rejected origin is deliberately absent from the response: echoing attacker
+    // -controlled input back into a body is how a diagnostic becomes a reflection bug.
+    res.status(403).json({ error: 'origin_not_allowed' });
+  };
+}
+
+/**
+ * Requires a shared secret in `Authorization: Bearer <token>` once `MCP_AUTH_TOKEN` is
+ * set. An unset (or blank) token disables the check entirely, which is what an existing
+ * deployment gets on upgrade.
+ */
+export function createAuthMiddleware(token: string | undefined): RequestHandler {
+  const expected = token?.trim();
+
+  if (!expected) {
+    return (_req, _res, next) => next();
+  }
+
+  // Compare SHA-256 digests rather than the tokens themselves. `timingSafeEqual` throws
+  // on length-mismatched inputs, so a direct comparison needs a length guard in front of
+  // it — and that guard is itself a side channel that hands an attacker the token's
+  // length for free. Digests are always 32 bytes, so one constant-time comparison covers
+  // every case and no branch depends on the presented value.
+  const expectedDigest = createHash('sha256').update(expected, 'utf8').digest();
+
+  return (req, res, next) => {
+    const header = req.headers.authorization;
+    const presented = typeof header === 'string' && /^bearer /i.test(header)
+      ? header.slice('bearer '.length)
+      : '';
+
+    const presentedDigest = createHash('sha256').update(presented, 'utf8').digest();
+
+    if (timingSafeEqual(expectedDigest, presentedDigest)) {
+      next();
+      return;
+    }
+
+    // A missing, malformed, and merely wrong credential all land here with byte-identical
+    // responses. Distinguishing them would tell a caller probing the endpoint which half
+    // of the guess to keep.
+    res.status(401).set('WWW-Authenticate', 'Bearer').json({ error: 'unauthorized' });
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import express from 'express';
 import cors from 'cors';
 import rateLimit from 'express-rate-limit';
 import { createServer } from './server.js';
+import { parseAllowedOrigins, createOriginMiddleware, createAuthMiddleware } from './http-security.js';
 import type { UptimeKumaConfig } from './types/index.js';
 
 /**
@@ -77,6 +78,12 @@ Examples:
   mcp-uptime-kuma -t stdio                 # Run with stdio transport
   mcp-uptime-kuma -t streamable-http       # Run with streamable HTTP transport (port 3000)
   PORT=8080 mcp-uptime-kuma -t streamable-http  # Run HTTP on custom port
+
+Environment variables for the streamable HTTP transport:
+  MCP_AUTH_TOKEN   Shared secret required as 'Authorization: Bearer <token>'. Unset = no auth.
+  ALLOWED_ORIGIN   Comma-separated origins allowed to call /mcp. Default '*' = no validation.
+  HOST             Address to bind. Default '0.0.0.0'; use '127.0.0.1' for local-only.
+  PORT             Port to listen on. Default 3000.
 `);
       process.exit(0);
     }
@@ -134,16 +141,13 @@ async function runHttp(config: UptimeKumaConfig) {
   const app = express();
   app.use(express.json());
 
-  // CORS configuration for MCP client compatibility
-  app.use(
-    cors({
-      origin: process.env.ALLOWED_ORIGIN || '*',
-      exposedHeaders: ['mcp-session-id'],
-      allowedHeaders: ['Content-Type', 'mcp-session-id', 'mcp-protocol-version'],
-    })
-  );
+  const allowedOrigins = parseAllowedOrigins(process.env.ALLOWED_ORIGIN);
+  const authToken = process.env.MCP_AUTH_TOKEN;
 
-  // Rate limiting: 100 requests per 15 minutes per IP
+  // Rate limiting: 100 requests per 15 minutes per IP.
+  //
+  // Stays outermost so that an unauthenticated flood is throttled before it reaches
+  // anything that does work — including the guards below.
   app.use(
     rateLimit({
       windowMs: 15 * 60 * 1000,
@@ -153,6 +157,28 @@ async function runHttp(config: UptimeKumaConfig) {
       message: 'Too many requests from this IP, please try again later.',
     })
   );
+
+  // Origin validation ahead of authentication, so a caller from an origin we do not
+  // recognise never gets to probe whether its token is correct. Both guards are scoped
+  // to the MCP endpoint: /health has to stay reachable for container healthchecks and
+  // load balancer probes, and it discloses nothing beyond the fact that we are running.
+  app.use('/mcp', createOriginMiddleware(allowedOrigins));
+
+  // CORS configuration for MCP client compatibility. `Authorization` MUST be listed:
+  // without it a browser-based client's preflight rejects the very header the auth
+  // guard below requires.
+  app.use(
+    cors({
+      origin: allowedOrigins,
+      exposedHeaders: ['mcp-session-id'],
+      allowedHeaders: ['Content-Type', 'Authorization', 'mcp-session-id', 'mcp-protocol-version'],
+    })
+  );
+
+  // Authentication AFTER cors, which answers `OPTIONS` preflights itself. A preflight
+  // carries no `Authorization` header by definition, so a guard placed ahead of cors
+  // would 401 every browser client before it ever sent its credential.
+  app.use('/mcp', createAuthMiddleware(authToken));
 
   // Create the MCP server once (reused across requests)
   const { server, authenticateClient } = await createServer(config);
@@ -223,10 +249,32 @@ async function runHttp(config: UptimeKumaConfig) {
   });
 
   const port = parseInt(process.env.PORT || '3000');
-  
-  const httpServer = app.listen(port, () => {
+
+  // Defaults to all interfaces. The MCP spec prefers binding to loopback for a local
+  // server, but this image's whole purpose is to be reached from outside its container,
+  // where 0.0.0.0 is mandatory — so the safer value is offered rather than imposed.
+  const host = process.env.HOST || '0.0.0.0';
+
+  const httpServer = app.listen(port, host, () => {
     console.log(`mcp-uptime-kuma server running on http://localhost:${port}/mcp`);
     console.log(`Health check available at http://localhost:${port}/health`);
+
+    // Warn rather than refuse to start. Both settings default to permissive so that
+    // upgrading cannot break a working deployment, which makes an unprotected server the
+    // quiet outcome — and a quiet outcome is exactly what nobody notices.
+    if (!authToken?.trim()) {
+      console.warn(
+        'WARNING: MCP_AUTH_TOKEN is not set. This endpoint is unauthenticated — anyone who can '
+        + 'reach it has full read/write control of your Uptime Kuma instance, including deleting monitors.'
+      );
+    }
+    if (allowedOrigins === '*') {
+      console.warn(
+        'WARNING: ALLOWED_ORIGIN is "*", so no Origin validation is performed. A website the user '
+        + 'visits can reach this server via DNS rebinding. Set ALLOWED_ORIGIN to a comma-separated '
+        + 'list of the origins your browser-based clients actually use.'
+      );
+    }
   }).on('error', (error) => {
     process.stderr.write(`Server error: ${error}\n`);
     process.exit(1);

--- a/test/unit/http-security.test.ts
+++ b/test/unit/http-security.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from 'vitest';
+import type { Request, Response } from 'express';
+import {
+  parseAllowedOrigins,
+  createOriginMiddleware,
+  createAuthMiddleware,
+} from '../../src/http-security.js';
+
+/**
+ * The middleware under test only ever reads two headers and, on rejection, writes a
+ * status/header/body. Stubbing that surface keeps these tests on the guard logic itself
+ * rather than on Express's routing, and means no socket is ever opened.
+ */
+interface StubResult {
+  req: Request;
+  res: Response;
+  nextCalls: number;
+  status?: number;
+  headers: Record<string, string>;
+  body?: unknown;
+  next: () => void;
+}
+
+function stub(headers: Record<string, string> = {}): StubResult {
+  const result: Partial<StubResult> & { nextCalls: number; headers: Record<string, string> } = {
+    nextCalls: 0,
+    headers: {},
+  };
+
+  const res = {
+    status(code: number) {
+      result.status = code;
+      return res;
+    },
+    set(name: string, value: string) {
+      result.headers[name] = value;
+      return res;
+    },
+    json(payload: unknown) {
+      result.body = payload;
+      return res;
+    },
+  } as unknown as Response;
+
+  result.req = { headers } as unknown as Request;
+  result.res = res;
+  result.next = () => {
+    result.nextCalls += 1;
+  };
+
+  return result as StubResult;
+}
+
+describe('parseAllowedOrigins', () => {
+  it('defaults to the wildcard when unset, preserving existing deployments', () => {
+    expect(parseAllowedOrigins(undefined)).toBe('*');
+  });
+
+  it('treats a blank value as unset rather than as an empty allowlist', () => {
+    expect(parseAllowedOrigins('')).toBe('*');
+    expect(parseAllowedOrigins('   ')).toBe('*');
+  });
+
+  it('recognises the explicit wildcard', () => {
+    expect(parseAllowedOrigins('*')).toBe('*');
+  });
+
+  it('splits a comma-separated list', () => {
+    expect(parseAllowedOrigins('https://a.example.com,https://b.example.com')).toEqual([
+      'https://a.example.com',
+      'https://b.example.com',
+    ]);
+  });
+
+  it('tolerates whitespace and empty entries around the separators', () => {
+    expect(parseAllowedOrigins(' https://a.example.com , , https://b.example.com ')).toEqual([
+      'https://a.example.com',
+      'https://b.example.com',
+    ]);
+  });
+
+  it('normalises case and a trailing slash so equality comparison is safe', () => {
+    expect(parseAllowedOrigins('HTTPS://Example.COM/')).toEqual(['https://example.com']);
+  });
+});
+
+describe('createOriginMiddleware', () => {
+  it('allows a request with no Origin header, which is every native MCP client', () => {
+    const s = stub({});
+    createOriginMiddleware(['https://example.com'])(s.req, s.res, s.next);
+    expect(s.nextCalls).toBe(1);
+    expect(s.status).toBeUndefined();
+  });
+
+  it('allows any Origin when configured with the wildcard', () => {
+    const s = stub({ origin: 'https://anything.example.com' });
+    createOriginMiddleware('*')(s.req, s.res, s.next);
+    expect(s.nextCalls).toBe(1);
+  });
+
+  it('allows an Origin on the allowlist', () => {
+    const s = stub({ origin: 'https://example.com' });
+    createOriginMiddleware(['https://example.com'])(s.req, s.res, s.next);
+    expect(s.nextCalls).toBe(1);
+  });
+
+  it('matches scheme and host case-insensitively', () => {
+    const s = stub({ origin: 'HTTPS://Example.com' });
+    createOriginMiddleware(['https://example.com'])(s.req, s.res, s.next);
+    expect(s.nextCalls).toBe(1);
+  });
+
+  it('rejects an Origin that is not on the allowlist with 403', () => {
+    const s = stub({ origin: 'https://evil.example.com' });
+    createOriginMiddleware(['https://example.com'])(s.req, s.res, s.next);
+    expect(s.status).toBe(403);
+    expect(s.nextCalls).toBe(0);
+  });
+
+  it('rejects a suffix near-miss rather than substring-matching the allowlist', () => {
+    const s = stub({ origin: 'https://evil-example.com' });
+    createOriginMiddleware(['https://example.com'])(s.req, s.res, s.next);
+    expect(s.status).toBe(403);
+    expect(s.nextCalls).toBe(0);
+  });
+
+  it('treats the port as significant', () => {
+    const s = stub({ origin: 'http://localhost:4000' });
+    createOriginMiddleware(['http://localhost:3000'])(s.req, s.res, s.next);
+    expect(s.status).toBe(403);
+    expect(s.nextCalls).toBe(0);
+  });
+
+  it('rejects the opaque "null" Origin a sandboxed frame sends', () => {
+    const s = stub({ origin: 'null' });
+    createOriginMiddleware(['https://example.com'])(s.req, s.res, s.next);
+    expect(s.status).toBe(403);
+    expect(s.nextCalls).toBe(0);
+  });
+
+  it('does not echo the rejected Origin back to the caller', () => {
+    const s = stub({ origin: 'https://evil.example.com' });
+    createOriginMiddleware(['https://example.com'])(s.req, s.res, s.next);
+    expect(JSON.stringify(s.body)).not.toContain('evil.example.com');
+  });
+});
+
+describe('createAuthMiddleware', () => {
+  const TOKEN = 'correct-horse-battery-staple';
+
+  it('passes every request through when no token is configured', () => {
+    const s = stub({});
+    createAuthMiddleware(undefined)(s.req, s.res, s.next);
+    expect(s.nextCalls).toBe(1);
+    expect(s.status).toBeUndefined();
+  });
+
+  it('treats a blank configured token as unset rather than as a token of ""', () => {
+    const s = stub({});
+    createAuthMiddleware('   ')(s.req, s.res, s.next);
+    expect(s.nextCalls).toBe(1);
+  });
+
+  it('rejects a request with no Authorization header', () => {
+    const s = stub({});
+    createAuthMiddleware(TOKEN)(s.req, s.res, s.next);
+    expect(s.status).toBe(401);
+    expect(s.nextCalls).toBe(0);
+  });
+
+  it('rejects a non-Bearer authorization scheme', () => {
+    const s = stub({ authorization: `Basic ${TOKEN}` });
+    createAuthMiddleware(TOKEN)(s.req, s.res, s.next);
+    expect(s.status).toBe(401);
+    expect(s.nextCalls).toBe(0);
+  });
+
+  it('rejects a wrong token of the same length', () => {
+    const wrong = 'x'.repeat(TOKEN.length);
+    const s = stub({ authorization: `Bearer ${wrong}` });
+    createAuthMiddleware(TOKEN)(s.req, s.res, s.next);
+    expect(s.status).toBe(401);
+    expect(s.nextCalls).toBe(0);
+  });
+
+  it('rejects a wrong token of a different length without throwing', () => {
+    const s = stub({ authorization: 'Bearer short' });
+    createAuthMiddleware(TOKEN)(s.req, s.res, s.next);
+    expect(s.status).toBe(401);
+    expect(s.nextCalls).toBe(0);
+  });
+
+  it('rejects a token that is merely a prefix of the configured one', () => {
+    const s = stub({ authorization: `Bearer ${TOKEN.slice(0, -1)}` });
+    createAuthMiddleware(TOKEN)(s.req, s.res, s.next);
+    expect(s.status).toBe(401);
+    expect(s.nextCalls).toBe(0);
+  });
+
+  it('accepts the configured token', () => {
+    const s = stub({ authorization: `Bearer ${TOKEN}` });
+    createAuthMiddleware(TOKEN)(s.req, s.res, s.next);
+    expect(s.nextCalls).toBe(1);
+    expect(s.status).toBeUndefined();
+  });
+
+  it('accepts the scheme in any case, as RFC 9110 requires', () => {
+    const s = stub({ authorization: `bearer ${TOKEN}` });
+    createAuthMiddleware(TOKEN)(s.req, s.res, s.next);
+    expect(s.nextCalls).toBe(1);
+  });
+
+  it('ignores surrounding whitespace on the configured token', () => {
+    const s = stub({ authorization: `Bearer ${TOKEN}` });
+    createAuthMiddleware(`  ${TOKEN}  `)(s.req, s.res, s.next);
+    expect(s.nextCalls).toBe(1);
+  });
+
+  it('advertises Bearer via WWW-Authenticate when rejecting', () => {
+    const s = stub({});
+    createAuthMiddleware(TOKEN)(s.req, s.res, s.next);
+    expect(s.headers['WWW-Authenticate']).toBe('Bearer');
+  });
+
+  it('answers a missing and an incorrect token identically, leaking no oracle', () => {
+    const missing = stub({});
+    createAuthMiddleware(TOKEN)(missing.req, missing.res, missing.next);
+
+    const incorrect = stub({ authorization: 'Bearer nope' });
+    createAuthMiddleware(TOKEN)(incorrect.req, incorrect.res, incorrect.next);
+
+    expect(incorrect.status).toBe(missing.status);
+    expect(incorrect.body).toEqual(missing.body);
+    expect(incorrect.headers).toEqual(missing.headers);
+  });
+
+  it('never puts the configured token in the rejection response', () => {
+    const s = stub({ authorization: 'Bearer wrong' });
+    createAuthMiddleware(TOKEN)(s.req, s.res, s.next);
+    expect(JSON.stringify({ body: s.body, headers: s.headers })).not.toContain(TOKEN);
+  });
+});


### PR DESCRIPTION
Closes #62.

## What

The HTTP transport had no protection of its own — anyone who could reach `/mcp` had full read/write control of the Uptime Kuma instance behind it, `deleteMonitor` included.

#62 asks for a shared secret, which is the MCP specification's **SHOULD** for this transport. While implementing it, the spec's **MUST** — [`Origin` validation](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#security-warning) — turned out to be missing as well, so this covers both.

## Why CORS wasn't already doing this

The `cors()` middleware already in `runHttp` is not Origin validation. It only sets response headers telling a browser whether the calling page may *read* the reply; the request has already run by then. That distinction is academic for a read-only server and decisive for this one.

It matters most in the attack the spec actually names. Under DNS rebinding a page on `evil.example` resolves its own hostname to `127.0.0.1`, so the browser treats the request as same-origin — no preflight fires, no `Access-Control-*` check applies. The server comparing the `Origin` header it was sent against the origins it expects is the only check left standing.

## Changes

**New `src/http-security.ts`** — `parseAllowedOrigins`, `createOriginMiddleware`, `createAuthMiddleware`.

- The token is compared as a **SHA-256 digest**, so one constant-time comparison covers every case. Comparing raw tokens requires a length guard ahead of `timingSafeEqual` (it throws on mismatched lengths), and that guard hands an attacker the token's length for free.
- Missing, malformed, and merely wrong credentials all produce **byte-identical 401s** — no oracle.
- Origin matching is exact equality on a normalised origin. No substring or suffix matching, which is how `https://evil-example.com` ends up passing a check meant for `https://example.com`.
- Requests with **no** `Origin` header pass the origin guard. That is every native MCP client (Claude Code, Claude Desktop, Cursor, VS Code); the guard exists to constrain browsers, the only agent rebinding can weaponise.

**Middleware ordering in `runHttp`** is load-bearing:

```
rateLimit → originGuard → cors → authGuard → handler
```

- Rate limiting stays outermost so unauthenticated floods are throttled before anything does work.
- Origin precedes auth so an unrecognised caller never gets to probe whether its token is correct.
- Auth follows `cors` because `cors` answers `OPTIONS` preflights, and a preflight carries no `Authorization` header by definition — an auth guard ahead of it would 401 every browser client before it could send a credential. `Authorization` is added to `allowedHeaders` for the same reason.
- Both guards are scoped to `/mcp`, leaving `/health` reachable for container healthchecks.

**Defaults stay permissive** so upgrading cannot break a working deployment — which makes an unprotected server the quiet outcome, so the server warns loudly at startup in that state. Flipping either default is available as a follow-up if you'd rather take it as a major version.

**New `HOST` variable**, defaulting to the current `0.0.0.0` rather than the loopback the spec prefers, because the published image must be reachable from outside its container. The safer value is offered in the docs rather than imposed.

Nothing in the stdio path changes — the spec is explicit that a stdio server takes its credentials from the environment and has no listener to protect.

| Variable | Default | Purpose |
|----------|---------|---------|
| `MCP_AUTH_TOKEN` | unset (no auth) | Shared secret required as `Authorization: Bearer <token>`; anything else gets `401` |
| `ALLOWED_ORIGIN` | `*` (no validation) | Comma-separated browser origins permitted to call `/mcp`; others get `403` |
| `HOST` | `0.0.0.0` | Bind address; `127.0.0.1` for local-only |

## Testing

28 new unit tests in `test/unit/http-security.test.ts` (full suite: 167 passing, typecheck and build clean). Covers wrong-length tokens, equal-length wrong tokens, prefix tokens, non-Bearer schemes, case-insensitive scheme handling, the 401 response being identical across failure modes, the token never appearing in a response, suffix near-miss origins, port mismatches, and the opaque `null` origin a sandboxed frame sends.

Verified against a live server on a throwaway port, since the unit tests cover the guards in isolation but not the ordering:

| Request | Result |
|---|---|
| `GET /health`, no credentials | `200` |
| `POST /mcp`, no token | `401` |
| `POST /mcp`, wrong token | `401` |
| `POST /mcp`, disallowed Origin **+ correct token** | `403` — origin guard runs first |
| `OPTIONS /mcp` preflight, allowed Origin | `204`, not `401` — cors sits ahead of auth |
| `POST /mcp`, correct token | reaches the handler |

Startup warnings confirmed to fire when unset and stay silent when configured.

## Follow-up not included here

Full OAuth 2.1 resource-server mode — RFC 9728 protected resource metadata at `/.well-known/oauth-protected-resource`, JWKS validation against an OIDC issuer, audience binding — is the spec-complete version of this and a much larger change. Happy to open a tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
