### PR TITLE
fix: finish #65 — stop coercing junk into numeric arguments, and filter summaries by parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,14 @@ See [Authentication Methods](#authentication-methods) for JWT token and anonymou
 - **active**: Filter by active (`true`) or inactive (`false`) monitors
 - **maintenance**: Filter by maintenance mode status
 - **tags**: Tag name and optional value, comma-separated (e.g., `"production"`, `"env=staging"`)
+- **parentId**: Group monitor ID, returning that group's **direct** children. Pass `null` for top-level monitors (those with no parent). Not recursive — to walk deeper, use each child group's own `childrenIDs`.
 - **status** (getMonitorSummary only): Heartbeat status (`"0"`=DOWN, `"1"`=UP, `"2"`=PENDING, `"3"`=MAINTENANCE)
-- **parentId** (listMonitors only): Group monitor ID, returning that group's **direct** children. Pass `null` for top-level monitors (those with no parent). Not recursive — to walk deeper, use each child group's own `childrenIDs`.
 
 **Examples:**
 ```javascript
-getMonitorSummary({ status: "0" })                    // All DOWN monitors
+getMonitorSummary({ status: "0" })                     // All DOWN monitors
 getMonitorSummary({ type: "http", maintenance: true }) // HTTP monitors in maintenance
+getMonitorSummary({ parentId: 12, status: "0" })       // What's down inside group 12
 listMonitors({ tags: "production,region=us-east" })    // Monitors with specific tags
 listMonitors({ parentId: 12 })                         // Direct children of group 12
 listMonitors({ parentId: null })                       // Top-level monitors only

--- a/README.md
+++ b/README.md
@@ -152,12 +152,15 @@ See [Authentication Methods](#authentication-methods) for JWT token and anonymou
 - **maintenance**: Filter by maintenance mode status
 - **tags**: Tag name and optional value, comma-separated (e.g., `"production"`, `"env=staging"`)
 - **status** (getMonitorSummary only): Heartbeat status (`"0"`=DOWN, `"1"`=UP, `"2"`=PENDING, `"3"`=MAINTENANCE)
+- **parentId** (listMonitors only): Group monitor ID, returning that group's **direct** children. Pass `null` for top-level monitors (those with no parent). Not recursive — to walk deeper, use each child group's own `childrenIDs`.
 
 **Examples:**
 ```javascript
 getMonitorSummary({ status: "0" })                    // All DOWN monitors
 getMonitorSummary({ type: "http", maintenance: true }) // HTTP monitors in maintenance
 listMonitors({ tags: "production,region=us-east" })    // Monitors with specific tags
+listMonitors({ parentId: 12 })                         // Direct children of group 12
+listMonitors({ parentId: null })                       // Top-level monitors only
 ```
 
 ## Authentication Methods

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,34 @@ import {
 import { VERSION } from './version.js';
 
 /**
+ * A required Uptime Kuma record ID (monitorID, notificationID, dockerHostID, tagID).
+ *
+ * These were declared `z.coerce.number().int().nonnegative()`, which is the root cause of #65.
+ * Coercion runs `Number()` over whatever arrives, and that costs twice:
+ *
+ *   - An ABSENT field becomes NaN, so the caller is told "expected number, received nan" —
+ *     a type complaint about a field they never wrote, rather than "this field is missing".
+ *     That is what made a misspelled `monitorId` so confusing to diagnose: the unknown key is
+ *     rejected, the declared key is then absent, and the absence was reported as a bad number.
+ *   - `Number(null)`, `Number('')` and `Number([])` are all 0, and `Number(true)` is 1, so
+ *     `getMonitor {monitorID: null}` did not fail at all — it read monitor 0. Junk silently
+ *     became a real ID, which is worse than a confusing message.
+ *
+ * Plain `z.number()` fixes both but would break clients that stringify their arguments, which
+ * is why the coercion was there. So strings are still accepted, but only ones that are
+ * actually a number: the preprocess step converts a numeric string and passes everything else
+ * through untouched, letting `z.number()` report what really arrived.
+ */
+function requiredId(description: string) {
+  return z.preprocess(
+    (value) => (typeof value === 'string' && /^\s*\d+\s*$/.test(value) ? Number(value) : value),
+    z.number({ required_error: `${description} — this field is required and was not provided` })
+      .int()
+      .nonnegative()
+  ).describe(description);
+}
+
+/**
  * Creates and configures the MCP server with tools, resources, and prompts
  * Note: Authentication must be done separately after connecting the transport
  */
@@ -306,7 +334,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       title: 'Get Monitor',
       description: 'Retrieves configuration details for a specific monitor by ID (URL, check interval, notification settings, etc.). Use this when you need to examine or modify settings for a specific monitor. For current status, use getMonitorSummary instead. By default returns only common fields plus runtime data (uptime, avgPing); set includeTypeSpecificFields to true to include type-specific fields (e.g., url for HTTP, hostname/port for TCP).',
       inputSchema: {
-        monitorID: z.coerce.number().int().nonnegative().describe('The ID of the monitor to retrieve'),
+        monitorID: requiredId('The ID of the monitor to retrieve'),
         includeTypeSpecificFields: z.boolean().optional().describe('Include type-specific fields (url, hostname, port, etc.) in addition to common fields. Default: false. When false, only returns MonitorBase fields plus uptime/avgPing.'),
         includeSecrets: includeSecretsParam
       },
@@ -349,7 +377,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
     'listMonitors',
     {
       title: 'List Monitors',
-      description: 'Retrieves configuration details for all monitors (URLs, check intervals, notification settings, etc.). Use this when you need to examine or modify monitor settings. For status checks ("how is everything doing?", "what\'s down?"), use getMonitorSummary instead. By default returns only common fields plus runtime data (uptime, avgPing); set includeTypeSpecificFields to true to include type-specific fields (e.g., url for HTTP, hostname/port for TCP). Supports filtering by keywords, type, active/maintenance status, and tags.',
+      description: 'Retrieves configuration details for all monitors (URLs, check intervals, notification settings, etc.). Use this when you need to examine or modify monitor settings. For status checks ("how is everything doing?", "what\'s down?"), use getMonitorSummary instead. By default returns only common fields plus runtime data (uptime, avgPing); set includeTypeSpecificFields to true to include type-specific fields (e.g., url for HTTP, hostname/port for TCP). Supports filtering by keywords, type, active/maintenance status, tags, and parent group.',
       inputSchema: {
         includeTypeSpecificFields: z.boolean().optional().describe('Include type-specific fields (url, hostname, port, etc.) in addition to common fields. Default: false. When false, only returns MonitorBase fields plus uptime/avgPing.'),
         keywords: z.string().optional().describe('Space-separated keywords to filter monitors by pathName (case-insensitive fuzzy match). All keywords must match for a monitor to be included.'),
@@ -506,7 +534,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       title: 'Get Heartbeats',
       description: 'Retrieves historical heartbeat data for a specific monitor (response times, status changes over time). Use this for analyzing patterns or history for one monitor. Beats are returned NEWEST-FIRST. By default returns only the most recent heartbeat; set maxHeartbeats (up to 100) for historical analysis. Keep maxHeartbeats ≤10 unless user requests more. Set important:true for the status CHANGES only (Uptime Kuma\'s own event list) — that is history, not current state, so do not read status from it. Credentials embedded in a status message URL (user:pass@host) read "***" unless includeSecrets is set.',
       inputSchema: {
-        monitorID: z.coerce.number().int().nonnegative().describe('The ID of the monitor to get heartbeats for'),
+        monitorID: requiredId('The ID of the monitor to get heartbeats for'),
         maxHeartbeats: z.coerce.number().int().positive().max(100).optional().describe('If set, returns the most recent X heartbeats (up to 100). If unset, returns only the most recent heartbeat (default: 1)'),
         // `limit` and `count` are what a caller reaches for first. Both used to be stripped,
         // leaving maxHeartbeats undefined and the call silently returning a single beat.
@@ -678,7 +706,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       title: 'Pause Monitor',
       description: 'Pauses a monitor, stopping it from performing checks. The monitor will remain in the system but will not send notifications or collect data until resumed.',
       inputSchema: {
-        monitorID: z.coerce.number().int().nonnegative().describe('The ID of the monitor to pause')
+        monitorID: requiredId('The ID of the monitor to pause')
       },
       outputSchema: {
         ok: z.boolean(),
@@ -718,7 +746,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       title: 'Resume Monitor',
       description: 'Resumes a paused monitor, restarting all checks. Use this to re-enable monitoring after pausing.',
       inputSchema: {
-        monitorID: z.coerce.number().int().nonnegative().describe('The ID of the monitor to resume')
+        monitorID: requiredId('The ID of the monitor to resume')
       },
       outputSchema: {
         ok: z.boolean(),
@@ -1098,7 +1126,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       title: 'Update Monitor',
       description: 'Updates an existing monitor configuration. You must include the monitorID. Only the fields you provide will be changed (the server merges your changes with the existing config). Use getMonitor first to get the current config.',
       inputSchema: {
-        monitorID: z.coerce.number().int().nonnegative().describe('The ID of the monitor to update'),
+        monitorID: requiredId('The ID of the monitor to update'),
         // `parent` was declared on createMonitor but not here, so an existing monitor could
         // never be moved into or out of a group (issue #63). The merge below then folded the
         // old value back in and Uptime Kuma replied "Saved." — a no-op reported as success.
@@ -1235,7 +1263,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       title: 'Delete Monitor',
       description: 'Permanently deletes a monitor and all its heartbeat history. This action cannot be undone.',
       inputSchema: {
-        monitorID: z.coerce.number().int().nonnegative().describe('The ID of the monitor to delete'),
+        monitorID: requiredId('The ID of the monitor to delete'),
       },
       outputSchema: {
         ok: z.boolean(),
@@ -1347,7 +1375,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       title: 'Update Notification',
       description: 'Updates an existing notification channel. Use listNotifications to find the notification ID.',
       inputSchema: {
-        notificationID: z.coerce.number().int().nonnegative().describe('The ID of the notification to update'),
+        notificationID: requiredId('The ID of the notification to update'),
         name: z.string().optional().describe('Human-readable name'),
         type: z.string().optional().describe('Notification type'),
         isDefault: z.boolean().optional().describe('Enable by default for new monitors'),
@@ -1423,7 +1451,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       title: 'Delete Notification',
       description: 'Permanently deletes a notification channel. Monitors that used this channel will no longer send alerts through it.',
       inputSchema: {
-        notificationID: z.coerce.number().int().nonnegative().describe('The ID of the notification to delete'),
+        notificationID: requiredId('The ID of the notification to delete'),
       },
       outputSchema: {
         ok: z.boolean(),
@@ -1518,7 +1546,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       title: 'Update Docker Host',
       description: 'Updates an existing docker daemon connection. Use listDockerHosts to find the docker host ID. Only the fields you pass are changed — the others are preserved.',
       inputSchema: {
-        dockerHostID: z.coerce.number().int().nonnegative().describe('The ID of the docker host to update'),
+        dockerHostID: requiredId('The ID of the docker host to update'),
         name: z.string().optional().describe('New human-readable name'),
         dockerType: z.enum(['socket', 'tcp']).optional().describe('New connection type'),
         dockerDaemon: z.string().optional().describe('New socket path or TCP URL'),
@@ -1591,7 +1619,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       title: 'Delete Docker Host',
       description: 'Permanently deletes a docker daemon connection. Any monitors referencing it will have their docker_host cleared by Uptime Kuma (the monitors themselves are not deleted).',
       inputSchema: {
-        dockerHostID: z.coerce.number().int().nonnegative().describe('The ID of the docker host to delete'),
+        dockerHostID: requiredId('The ID of the docker host to delete'),
       },
       outputSchema: {
         ok: z.boolean(),
@@ -1715,7 +1743,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       title: 'Delete Tag',
       description: 'Permanently deletes a tag. It will be removed from all monitors that use it. Use listTags to find the tag ID.',
       inputSchema: {
-        tagID: z.coerce.number().int().nonnegative().describe('The ID of the tag to delete'),
+        tagID: requiredId('The ID of the tag to delete'),
       },
       outputSchema: {
         ok: z.boolean(),

--- a/src/server.ts
+++ b/src/server.ts
@@ -487,13 +487,17 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
     'getMonitorSummary',
     {
       title: 'Get Monitor Summary',
-      description: 'START HERE for status overview questions. Retrieves current status for all monitors showing UP/DOWN/PENDING/MAINTENANCE states with the most recent heartbeat message. Use this when asked "how is everything doing?", "what\'s down?", "what\'s up?", or for any general status overview. Returns essential information (ID, name, pathName, active state, maintenance state, status, message, lastBeatTime, type, tags). Supports filtering by keywords, type, active/maintenance status, tags, and current status. Check lastBeatTime before trusting the status of a push monitor — one that has stopped beating keeps reporting its last known status. lastBeatTime is UTC with no zone marker, so measure staleness against the current UTC time.',
+      description: 'START HERE for status overview questions. Retrieves current status for all monitors showing UP/DOWN/PENDING/MAINTENANCE states with the most recent heartbeat message. Use this when asked "how is everything doing?", "what\'s down?", "what\'s up?", or for any general status overview. Returns essential information (ID, name, pathName, active state, maintenance state, status, message, lastBeatTime, type, tags). Supports filtering by keywords, type, active/maintenance status, tags, parent group, and current status. Check lastBeatTime before trusting the status of a push monitor — one that has stopped beating keeps reporting its last known status. lastBeatTime is UTC with no zone marker, so measure staleness against the current UTC time.',
       inputSchema: {
         keywords: z.string().optional().describe('Space-separated keywords to filter monitors by pathName (case-insensitive fuzzy match). All keywords must match for a monitor to be included.'),
         type: z.string().optional().describe('Filter by monitor type(s). Comma-separated for multiple types. Use listMonitorTypes tool to see all available types.'),
         active: z.boolean().optional().describe('Filter by active status. true=only active monitors, false=only inactive monitors.'),
         maintenance: z.boolean().optional().describe('Filter by maintenance status. true=only monitors in maintenance, false=only monitors not in maintenance.'),
         tags: z.string().optional().describe('Filter by tag name and optional value. Comma-separated for multiple tags. Format: "tagName" or "tagName=value". Monitor must have all specified tags. Case-insensitive. Examples: "production", "env=staging", "production,region=us-east"'),
+        // "What's down in this group?" is a status question, so it arrives here rather than at
+        // listMonitors — but the #65 parent filter only reached listMonitors, leaving the tool
+        // the instructions send callers to FIRST unable to answer it.
+        parentId: z.union([z.null(), z.coerce.number().int()]).optional().describe('Filter to the DIRECT children of this group monitor. Pass null for top-level monitors (those with no parent). Not recursive — use the group\'s own childrenIDs to walk deeper.'),
         status: z.string().optional().describe('Filter by current heartbeat status. Comma-separated for multiple statuses. 0=DOWN, 1=UP, 2=PENDING, 3=MAINTENANCE. Examples: "0", "1", "0,2"')
       },
       outputSchema: { 
@@ -501,11 +505,11 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         count: z.number()
       },
     },
-    async ({ keywords, type, active, maintenance, tags, status }) => {
+    async ({ keywords, type, active, maintenance, tags, parentId, status }) => {
       await authenticateClient();
 
       try {
-        const summaries = client.getMonitorSummary({ keywords, type, active, maintenance, tags, status });
+        const summaries = client.getMonitorSummary({ keywords, type, active, maintenance, tags, parentId, status });
         
         return {
           content: [{ 

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,27 +16,57 @@ import {
 import { VERSION } from './version.js';
 
 /**
- * A required Uptime Kuma record ID (monitorID, notificationID, dockerHostID, tagID).
+ * Converts a string that really is a number, and passes everything else through untouched.
  *
- * These were declared `z.coerce.number().int().nonnegative()`, which is the root cause of #65.
- * Coercion runs `Number()` over whatever arrives, and that costs twice:
+ * This replaces `z.coerce.number()`, which is the root cause of #65. Coercion runs `Number()`
+ * over whatever arrives, unconditionally, and that costs twice:
  *
  *   - An ABSENT field becomes NaN, so the caller is told "expected number, received nan" —
  *     a type complaint about a field they never wrote, rather than "this field is missing".
  *     That is what made a misspelled `monitorId` so confusing to diagnose: the unknown key is
  *     rejected, the declared key is then absent, and the absence was reported as a bad number.
  *   - `Number(null)`, `Number('')` and `Number([])` are all 0, and `Number(true)` is 1, so
- *     `getMonitor {monitorID: null}` did not fail at all — it read monitor 0. Junk silently
- *     became a real ID, which is worse than a confusing message.
+ *     junk silently became a plausible value. `getMonitor {monitorID: null}` read monitor 0,
+ *     and on the write tools it was worse: `timeout: ''` stored a 0, and a stored 0 makes
+ *     Uptime Kuma compute a ~13 hour timeout (see the field's own description), so the monitor
+ *     can never report DOWN against a host that accepts the connection and never answers.
+ *     A silently disabled monitor is the worst failure an uptime tool has.
  *
- * Plain `z.number()` fixes both but would break clients that stringify their arguments, which
- * is why the coercion was there. So strings are still accepted, but only ones that are
- * actually a number: the preprocess step converts a numeric string and passes everything else
- * through untouched, letting `z.number()` report what really arrived.
+ * Dropping coercion entirely would fix both but break clients that stringify their arguments,
+ * which is why it was there. So the conversion is made CONDITIONAL: only strings that parse to
+ * a finite number are converted, and anything else reaches the validator unchanged, to be
+ * reported as what it actually was. `''` is excluded explicitly — `Number('')` is 0, and that
+ * single conversion is responsible for most of the damage above.
+ */
+function numericString(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  if (trimmed === '') return value;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : value;
+}
+
+/**
+ * Wraps a number schema so it accepts numeric strings without accepting junk.
+ *
+ * Takes the inner schema rather than returning a chainable one, because the call sites need
+ * their own constraints (`.int()`, `.positive()`, `.max(100)`) applied to the NUMBER, and those
+ * cannot be chained onto the effect wrapper this returns. `.optional()` and `.nullable()` are
+ * chained on the outside as usual, and still short-circuit before the conversion runs — so a
+ * field declared `.nullable()` keeps accepting null.
+ */
+function numeric<T extends z.ZodTypeAny>(schema: T) {
+  return z.preprocess(numericString, schema);
+}
+
+/**
+ * A required Uptime Kuma record ID (monitorID, notificationID, dockerHostID, tagID).
+ *
+ * `required_error` is what turns an absent field back into "this field is required" rather than
+ * the NaN complaint of #65.
  */
 function requiredId(description: string) {
-  return z.preprocess(
-    (value) => (typeof value === 'string' && /^\s*\d+\s*$/.test(value) ? Number(value) : value),
+  return numeric(
     z.number({ required_error: `${description} — this field is required and was not provided` })
       .int()
       .nonnegative()
@@ -387,7 +417,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         tags: z.string().optional().describe('Filter by tag name and optional value. Comma-separated for multiple tags. Format: "tagName" or "tagName=value". Monitor must have all specified tags. Case-insensitive. Examples: "production", "env=staging", "production,region=us-east"'),
         // Issue #65: there was no way to list a group's members, so callers passing
         // `parentId` got the entire monitor list back, which reads as a broken filter.
-        parentId: z.union([z.null(), z.coerce.number().int()]).optional().describe('Filter to the DIRECT children of this group monitor. Pass null for top-level monitors (those with no parent). Not recursive — use the group\'s own childrenIDs to walk deeper.'),
+        parentId: numeric(z.number().int()).nullable().optional().describe('Filter to the DIRECT children of this group monitor. Pass null for top-level monitors (those with no parent). Not recursive — use the group\'s own childrenIDs to walk deeper.'),
         includeSecrets: includeSecretsParam
       },
       outputSchema: {
@@ -497,7 +527,7 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         // "What's down in this group?" is a status question, so it arrives here rather than at
         // listMonitors — but the #65 parent filter only reached listMonitors, leaving the tool
         // the instructions send callers to FIRST unable to answer it.
-        parentId: z.union([z.null(), z.coerce.number().int()]).optional().describe('Filter to the DIRECT children of this group monitor. Pass null for top-level monitors (those with no parent). Not recursive — use the group\'s own childrenIDs to walk deeper.'),
+        parentId: numeric(z.number().int()).nullable().optional().describe('Filter to the DIRECT children of this group monitor. Pass null for top-level monitors (those with no parent). Not recursive — use the group\'s own childrenIDs to walk deeper.'),
         status: z.string().optional().describe('Filter by current heartbeat status. Comma-separated for multiple statuses. 0=DOWN, 1=UP, 2=PENDING, 3=MAINTENANCE. Examples: "0", "1", "0,2"')
       },
       outputSchema: { 
@@ -539,11 +569,11 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       description: 'Retrieves historical heartbeat data for a specific monitor (response times, status changes over time). Use this for analyzing patterns or history for one monitor. Beats are returned NEWEST-FIRST. By default returns only the most recent heartbeat; set maxHeartbeats (up to 100) for historical analysis. Keep maxHeartbeats ≤10 unless user requests more. Set important:true for the status CHANGES only (Uptime Kuma\'s own event list) — that is history, not current state, so do not read status from it. Credentials embedded in a status message URL (user:pass@host) read "***" unless includeSecrets is set.',
       inputSchema: {
         monitorID: requiredId('The ID of the monitor to get heartbeats for'),
-        maxHeartbeats: z.coerce.number().int().positive().max(100).optional().describe('If set, returns the most recent X heartbeats (up to 100). If unset, returns only the most recent heartbeat (default: 1)'),
+        maxHeartbeats: numeric(z.number().int().positive().max(100)).optional().describe('If set, returns the most recent X heartbeats (up to 100). If unset, returns only the most recent heartbeat (default: 1)'),
         // `limit` and `count` are what a caller reaches for first. Both used to be stripped,
         // leaving maxHeartbeats undefined and the call silently returning a single beat.
-        limit: z.coerce.number().int().positive().max(100).optional().describe('Alias for maxHeartbeats. Prefer maxHeartbeats.'),
-        count: z.coerce.number().int().positive().max(100).optional().describe('Alias for maxHeartbeats. Prefer maxHeartbeats.'),
+        limit: numeric(z.number().int().positive().max(100)).optional().describe('Alias for maxHeartbeats. Prefer maxHeartbeats.'),
+        count: numeric(z.number().int().positive().max(100)).optional().describe('Alias for maxHeartbeats. Prefer maxHeartbeats.'),
         important: z.boolean().optional().describe('Return only IMPORTANT beats — the status changes behind Uptime Kuma\'s event list — fetched live from the server rather than the cache. History only: the newest important beat is not the monitor\'s current status.'),
         includeSecrets: includeSecretsParam
       },
@@ -645,9 +675,9 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
       title: 'List Heartbeats',
       description: 'Retrieves historical heartbeat data for ALL monitors (response times, status changes over time). Use this for analyzing patterns across multiple monitors or correlating events. Beats are returned NEWEST-FIRST. By default returns only the most recent heartbeat per monitor; set maxHeartbeats (up to 100) for historical analysis. Keep maxHeartbeats ≤5 unless user requests more. Credentials embedded in a status message URL (user:pass@host) read "***" unless includeSecrets is set.',
       inputSchema: {
-        maxHeartbeats: z.coerce.number().int().positive().max(100).optional().describe('If set, returns the most recent X heartbeats per monitor (up to 100). If unset, returns only the most recent heartbeat per monitor (default: 1)'),
-        limit: z.coerce.number().int().positive().max(100).optional().describe('Alias for maxHeartbeats. Prefer maxHeartbeats.'),
-        count: z.coerce.number().int().positive().max(100).optional().describe('Alias for maxHeartbeats. Prefer maxHeartbeats.'),
+        maxHeartbeats: numeric(z.number().int().positive().max(100)).optional().describe('If set, returns the most recent X heartbeats per monitor (up to 100). If unset, returns only the most recent heartbeat per monitor (default: 1)'),
+        limit: numeric(z.number().int().positive().max(100)).optional().describe('Alias for maxHeartbeats. Prefer maxHeartbeats.'),
+        count: numeric(z.number().int().positive().max(100)).optional().describe('Alias for maxHeartbeats. Prefer maxHeartbeats.'),
         includeSecrets: includeSecretsParam
       },
       outputSchema: { 
@@ -960,8 +990,8 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         type: z.string().describe('Monitor type (e.g. http, port, ping, dns, push, keyword). Use listMonitorTypes for all options.'),
         description: z.string().nullable().optional().describe('Free-text description shown on the monitor page'),
         active: z.boolean().optional().describe('Whether the monitor starts checking immediately (default: true). Pass false to create it paused.'),
-        resendInterval: z.coerce.number().optional().describe('Resend notification every N checks while down (0 = disabled, the default)'),
-        timeout: z.coerce.number().nullable().optional().describe('Request timeout in SECONDS. Omit for 0.8 x interval. Avoid 0: Uptime Kuma\'s runtime fallback for a stored 0 computes interval * 1000 * 0.8 and then multiplies by 1000 again, yielding a ~13 hour timeout, so the monitor can never report DOWN against a host that accepts the connection and never answers.'),
+        resendInterval: numeric(z.number()).optional().describe('Resend notification every N checks while down (0 = disabled, the default)'),
+        timeout: numeric(z.number()).nullable().optional().describe('Request timeout in SECONDS. Omit for 0.8 x interval. Avoid 0: Uptime Kuma\'s runtime fallback for a stored 0 computes interval * 1000 * 0.8 and then multiplies by 1000 again, yielding a ~13 hour timeout, so the monitor can never report DOWN against a host that accepts the connection and never answers.'),
         jsonPath: z.string().optional().describe('JSONata expression for json-query monitors. Must resolve to a primitive.'),
         json_path: z.string().optional().describe('Alias for jsonPath (the database column name). Prefer jsonPath.'),
         jsonPathOperator: z.enum(['>', '>=', '<', '<=', '==', '!=', 'contains']).optional().describe('Comparison operator for json-query monitors. UP while value <operator> expectedValue.'),
@@ -972,10 +1002,10 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         push_token: z.string().min(8).optional().describe('Alias for pushToken (the database column name). Prefer pushToken.'),
         url: z.string().optional().describe('URL to monitor (required for http/keyword/json-query types)'),
         hostname: z.string().optional().describe('Hostname to monitor (required for port/ping/dns types)'),
-        port: z.coerce.number().optional().describe('Port number (required for port/tcp types)'),
-        interval: z.coerce.number().optional().describe('Check interval in seconds (default: 60)'),
-        retryInterval: z.coerce.number().optional().describe('Retry interval in seconds when monitor is down (default: 60)'),
-        maxretries: z.coerce.number().optional().describe('Max retries before marking as down (default: 0)'),
+        port: numeric(z.number()).optional().describe('Port number (required for port/tcp types)'),
+        interval: numeric(z.number()).optional().describe('Check interval in seconds (default: 60)'),
+        retryInterval: numeric(z.number()).optional().describe('Retry interval in seconds when monitor is down (default: 60)'),
+        maxretries: numeric(z.number()).optional().describe('Max retries before marking as down (default: 0)'),
         notificationIDList: z.record(z.string(), z.boolean()).optional().describe('Map of notification IDs to enable (e.g. {"1": true, "3": true})'),
         tags: z.array(z.object({
           name: z.string(),
@@ -989,11 +1019,11 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         headers: z.string().optional().describe('HTTP headers as JSON string'),
         accepted_statuscodes: z.array(z.string()).optional().describe('Accepted HTTP status codes (e.g. ["200-299"])'),
         ignoreTls: z.boolean().optional().describe('Ignore TLS/SSL errors'),
-        maxredirects: z.coerce.number().optional().describe('Max HTTP redirects (default: 10)'),
+        maxredirects: numeric(z.number()).optional().describe('Max HTTP redirects (default: 10)'),
         upsideDown: z.boolean().optional().describe('Invert status — treat up as down'),
-        parent: z.coerce.number().nullable().optional().describe('Parent group monitor ID'),
+        parent: numeric(z.number()).nullable().optional().describe('Parent group monitor ID'),
         docker_container: z.string().optional().describe('Docker container name (required for docker type)'),
-        docker_host: z.coerce.number().optional().describe('Docker host ID (required for docker type). Use listDockerHosts to find available IDs.'),
+        docker_host: numeric(z.number()).optional().describe('Docker host ID (required for docker type). Use listDockerHosts to find available IDs.'),
         dns_resolve_server: z.string().optional().describe('DNS server to use for resolution (required for dns type, default: 1.1.1.1)'),
         dns_resolve_type: z.enum(['A', 'AAAA', 'CNAME', 'MX', 'NS', 'PTR', 'SOA', 'SRV', 'TXT', 'CAA']).optional().describe('DNS record type to query (required for dns type, default: A)'),
       },
@@ -1134,12 +1164,12 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         // `parent` was declared on createMonitor but not here, so an existing monitor could
         // never be moved into or out of a group (issue #63). The merge below then folded the
         // old value back in and Uptime Kuma replied "Saved." — a no-op reported as success.
-        parent: z.coerce.number().int().nullable().optional().describe('Parent group monitor ID — re-parents this monitor into that group. Pass null to move it to the top level.'),
-        parentID: z.coerce.number().int().nullable().optional().describe('Alias for parent. Prefer parent.'),
-        parent_id: z.coerce.number().int().nullable().optional().describe('Alias for parent. Prefer parent.'),
+        parent: numeric(z.number().int()).nullable().optional().describe('Parent group monitor ID — re-parents this monitor into that group. Pass null to move it to the top level.'),
+        parentID: numeric(z.number().int()).nullable().optional().describe('Alias for parent. Prefer parent.'),
+        parent_id: numeric(z.number().int()).nullable().optional().describe('Alias for parent. Prefer parent.'),
         description: z.string().nullable().optional().describe('Free-text description shown on the monitor page'),
-        resendInterval: z.coerce.number().optional().describe('Resend notification every N checks while down (0 = disabled)'),
-        timeout: z.coerce.number().nullable().optional().describe('Request timeout in SECONDS. Avoid 0 — Uptime Kuma\'s runtime fallback for a stored 0 yields a ~13 hour timeout, so the monitor can never report DOWN against a black-holed endpoint.'),
+        resendInterval: numeric(z.number()).optional().describe('Resend notification every N checks while down (0 = disabled)'),
+        timeout: numeric(z.number()).nullable().optional().describe('Request timeout in SECONDS. Avoid 0 — Uptime Kuma\'s runtime fallback for a stored 0 yields a ~13 hour timeout, so the monitor can never report DOWN against a black-holed endpoint.'),
         jsonPath: z.string().optional().describe('JSONata expression for json-query monitors. Must resolve to a primitive.'),
         json_path: z.string().optional().describe('Alias for jsonPath (the database column name). Prefer jsonPath.'),
         jsonPathOperator: z.enum(['>', '>=', '<', '<=', '==', '!=', 'contains']).optional().describe('Comparison operator for json-query monitors.'),
@@ -1151,10 +1181,10 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         name: z.string().optional().describe('Display name'),
         url: z.string().optional().describe('URL to monitor'),
         hostname: z.string().optional().describe('Hostname'),
-        port: z.coerce.number().optional().describe('Port number'),
-        interval: z.coerce.number().optional().describe('Check interval in seconds'),
-        retryInterval: z.coerce.number().optional().describe('Retry interval in seconds'),
-        maxretries: z.coerce.number().optional().describe('Max retries before marking as down'),
+        port: numeric(z.number()).optional().describe('Port number'),
+        interval: numeric(z.number()).optional().describe('Check interval in seconds'),
+        retryInterval: numeric(z.number()).optional().describe('Retry interval in seconds'),
+        maxretries: numeric(z.number()).optional().describe('Max retries before marking as down'),
         notificationIDList: z.record(z.string(), z.boolean()).optional().describe('Notification ID map'),
         tags: z.array(z.object({
           name: z.string(),
@@ -1168,11 +1198,11 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         headers: z.string().optional().describe('HTTP headers as JSON string'),
         accepted_statuscodes: z.array(z.string()).optional().describe('Accepted HTTP status codes'),
         ignoreTls: z.boolean().optional().describe('Ignore TLS/SSL errors'),
-        maxredirects: z.coerce.number().optional().describe('Max HTTP redirects'),
+        maxredirects: numeric(z.number()).optional().describe('Max HTTP redirects'),
         upsideDown: z.boolean().optional().describe('Invert status'),
         active: z.boolean().optional().describe('Whether the monitor is active'),
         docker_container: z.string().optional().describe('Docker container name (required for docker type)'),
-        docker_host: z.coerce.number().optional().describe('Docker host ID (required for docker type). Use listDockerHosts to find available IDs.'),
+        docker_host: numeric(z.number()).optional().describe('Docker host ID (required for docker type). Use listDockerHosts to find available IDs.'),
         dns_resolve_server: z.string().optional().describe('DNS server to use for resolution (for dns type)'),
         dns_resolve_type: z.enum(['A', 'AAAA', 'CNAME', 'MX', 'NS', 'PTR', 'SOA', 'SRV', 'TXT', 'CAA']).optional().describe('DNS record type to query (for dns type)'),
       },
@@ -1812,13 +1842,13 @@ export async function createServer(config: UptimeKumaConfig): Promise<{ server: 
         active: z.boolean().optional().describe('Whether the window is active (default: true)'),
         timezone: z.string().optional().describe('Timezone (e.g. "America/New_York", "UTC"). Defaults to server timezone.'),
         dateRange: z.array(z.string()).optional().describe('Date range as [startISO, endISO] (required for single strategy)'),
-        timeRange: z.array(z.object({ hours: z.coerce.number(), minutes: z.coerce.number() })).optional()
+        timeRange: z.array(z.object({ hours: numeric(z.number()), minutes: numeric(z.number()) })).optional()
           .describe('Start and end time within the day as [{hours, minutes}, {hours, minutes}]'),
-        weekdays: z.array(z.coerce.number().int().min(0).max(6)).optional()
+        weekdays: z.array(numeric(z.number().int().min(0).max(6))).optional()
           .describe('Days of week (0=Sunday … 6=Saturday) for recurring-weekday strategy'),
-        daysOfMonth: z.array(z.coerce.number().int().min(1).max(31)).optional()
+        daysOfMonth: z.array(numeric(z.number().int().min(1).max(31))).optional()
           .describe('Days of month (1-31) for recurring-day-of-month strategy'),
-        intervalDay: z.coerce.number().int().positive().optional()
+        intervalDay: numeric(z.number().int().positive()).optional()
           .describe('Interval in days for recurring-interval strategy'),
       },
       outputSchema: {

--- a/src/uptime-kuma-client.ts
+++ b/src/uptime-kuma-client.ts
@@ -55,6 +55,25 @@ function filterToBaseWithExtendedData(monitor: MonitorWithExtendedData): Monitor
 }
 
 /**
+ * Does `monitor` satisfy a `parentId` filter? Direct children only, matching Uptime Kuma's
+ * own `parent` column — a grandchild belongs to its immediate group, not to the one above it.
+ *
+ * The distinction this exists to protect: `undefined` means "no parent filter" while `null` is
+ * a real, requestable value meaning "top level only". A truthiness check (`if (parentId)`)
+ * conflates them AND silently drops group 0, so the branch is written out longhand.
+ *
+ * Shared by getMonitorList and getMonitorSummary. Both keep their own copy of the surrounding
+ * filter loop, and the parent filter reaching only the first of them is exactly what had to be
+ * fixed here — so the subtle half lives in one place rather than being copied a second time.
+ */
+function matchesParentFilter(monitor: { parent?: number | null }, parentId: number | null | undefined): boolean {
+  if (parentId === undefined) return true;
+  const wanted = parentId === null ? null : Number(parentId);
+  const actual = monitor.parent === null || monitor.parent === undefined ? null : Number(monitor.parent);
+  return actual === wanted;
+}
+
+/**
  * Uptime Kuma Socket.io API Client
  */
 export class UptimeKumaClient {
@@ -646,18 +665,10 @@ export class UptimeKumaClient {
     // Parse tag filter from comma-separated string
     const tagFilter = filters?.tags ? filters.tags.split(',').map(t => t.trim()).filter(t => t.length > 0) : [];
 
-    // `undefined` means "no parent filter"; `null` is a real value meaning "top level only",
-    // so the two must not be conflated into a truthiness check.
-    const filterByParent = filters?.parentId !== undefined;
-    const wantedParent = filters?.parentId === null ? null : Number(filters?.parentId);
-
     for (const [monitorID, monitor] of Object.entries(this.monitorListCache)) {
       // Filter by parent group — direct children only, matching Uptime Kuma's `parent` column
-      if (filterByParent) {
-        const actualParent = monitor.parent === null || monitor.parent === undefined ? null : Number(monitor.parent);
-        if (actualParent !== wantedParent) {
-          continue;
-        }
+      if (!matchesParentFilter(monitor, filters?.parentId)) {
+        continue;
       }
 
     // Filter by keywords if provided using fuzzy matching
@@ -832,6 +843,7 @@ export class UptimeKumaClient {
     active?: boolean;
     maintenance?: boolean;
     tags?: string;
+    parentId?: number | null;
     status?: string;
   }): MonitorSummary[] {
     const summaries = [];
@@ -849,6 +861,11 @@ export class UptimeKumaClient {
     const statusFilter = filters?.status ? filters.status.split(',').map(s => parseInt(s.trim(), 10)).filter(n => !isNaN(n)) : [];
     
     for (const [monitorID, monitor] of Object.entries(this.monitorListCache)) {
+      // Filter by parent group — direct children only, matching Uptime Kuma's `parent` column
+      if (!matchesParentFilter(monitor, filters?.parentId)) {
+        continue;
+      }
+
       // Filter by keywords if provided using fuzzy matching
       if (keywordArray.length > 0) {
         const pathName = monitor.pathName || '';

--- a/test/integration/monitors.test.ts
+++ b/test/integration/monitors.test.ts
@@ -369,13 +369,23 @@ export const monitorTests: Array<{ name: string; fn: TestFn }> = [
           throw new Error(`parentId filter returned ${Array.isArray(listed) ? listed.length : 'non-array'} monitors, expected exactly the one child`);
         }
 
+        // The same filter on the tool the instructions send status questions to first —
+        // "what's down in this group?" reaches getMonitorSummary, not listMonitors.
+        const summarised = JSON.parse(extractText(
+          await client.callTool({ name: 'getMonitorSummary', arguments: { parentId: groupID } }) as CallToolResult,
+          'getMonitorSummary'
+        ));
+        if (!Array.isArray(summarised) || summarised.length !== 1 || Number(summarised[0].id) !== monitorID) {
+          throw new Error(`getMonitorSummary parentId returned ${Array.isArray(summarised) ? summarised.length : 'non-array'} monitors, expected exactly the one child`);
+        }
+
         await client.callTool({ name: 'updateMonitor', arguments: { monitorID, parent: null } });
         const back = JSON.parse(extractText(
           await client.callTool({ name: 'getMonitor', arguments: { monitorID } }) as CallToolResult,
           'getMonitor'
         ));
         if (back.parent !== null) throw new Error('re-parent to top level did not persist');
-        console.log('  ✓ #63/#65: re-parent works both ways; parentId returns direct children');
+        console.log('  ✓ #63/#65: re-parent works both ways; parentId returns direct children on both list and summary');
       } finally {
         await client.callTool({ name: 'deleteMonitor', arguments: { monitorID } });
         await client.callTool({ name: 'deleteMonitor', arguments: { monitorID: groupID } });

--- a/test/integration/strict-schema.test.ts
+++ b/test/integration/strict-schema.test.ts
@@ -107,6 +107,42 @@ export const strictSchemaTests: Array<{ name: string; fn: TestFn }> = [
     },
   },
   {
+    name: '#65: timeout:"" is refused rather than stored as the 0 that disables DOWN detection',
+    fn: async ({ client }) => {
+      const monitorID = extractID(await client.callTool({
+        name: 'createMonitor',
+        arguments: {
+          name: 'Integration Test - timeout coercion',
+          type: 'http',
+          url: 'https://example.com',
+          interval: 300,
+          active: false,
+        },
+      }) as CallToolResult, 'createMonitor', 'monitorID');
+
+      try {
+        // z.coerce.number() turned '' into 0, and Uptime Kuma's runtime fallback for a stored
+        // 0 yields a ~13 hour timeout — the monitor silently stops being able to report DOWN.
+        const message = await expectToolError(client, 'updateMonitor', { monitorID, timeout: '' });
+        if (!message.includes('timeout')) {
+          throw new Error(`error does not name the offending field: ${message}`);
+        }
+
+        // The rejection has to mean nothing was written, not merely that something complained.
+        const after = JSON.parse(extractText(
+          await client.callTool({ name: 'getMonitor', arguments: { monitorID } }) as CallToolResult,
+          'getMonitor'
+        ));
+        if (Number(after.timeout) !== 240) {
+          throw new Error(`timeout is now ${JSON.stringify(after.timeout)}, expected the original 240`);
+        }
+        console.log('  ✓ #65: timeout:"" rejected and the stored value left intact');
+      } finally {
+        await client.callTool({ name: 'deleteMonitor', arguments: { monitorID } });
+      }
+    },
+  },
+  {
     name: 'tools/list advertises additionalProperties:false',
     fn: async ({ client }) => {
       const { tools } = await client.listTools();

--- a/test/integration/strict-schema.test.ts
+++ b/test/integration/strict-schema.test.ts
@@ -40,13 +40,14 @@ export const strictSchemaTests: Array<{ name: string; fn: TestFn }> = [
       if (!/Accepted fields/.test(message)) {
         throw new Error(`error does not list the accepted fields: ${message}`);
       }
-      // The NaN complaint may still appear (Zod appends unrecognized_keys last), but it must
-      // not be the first thing read — that is the misleading half of #65.
-      const nanAt = message.toLowerCase().indexOf('nan');
-      if (nanAt !== -1 && message.indexOf('monitorId') > nanAt) {
-        throw new Error('the NaN complaint still precedes the unknown-key error');
+      // The NaN complaint used to appear underneath the unknown-key error, because the
+      // required IDs were `z.coerce.number()` and coercion turns the now-absent `monitorID`
+      // into NaN. Those are now declared with `requiredId`, so the absence is reported as an
+      // absence and the NaN line is gone entirely rather than merely demoted.
+      if (/nan/i.test(message)) {
+        throw new Error(`the NaN complaint is still present: ${message}`);
       }
-      console.log('  ✓ #65: unknown key named first, accepted fields listed');
+      console.log('  ✓ #65: unknown key named first, accepted fields listed, no NaN complaint');
     },
   },
   {

--- a/test/unit/id-argument-validation.test.ts
+++ b/test/unit/id-argument-validation.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { z } from 'zod';
+import { createServer } from '../../src/server.js';
+
+/**
+ * Issue #65, first half: required record IDs were declared `z.coerce.number()`.
+ *
+ * Coercion runs `Number()` over whatever arrives, which costs twice:
+ *
+ * 1. An ABSENT field coerces to NaN, so omitting `monitorID` (or misspelling it, since the
+ *    unknown key is rejected and the declared one is then missing) reported
+ *    "expected number, received nan" — a type complaint about a field the caller never wrote,
+ *    rather than "this required field is missing".
+ * 2. `Number(null)`, `Number('')` and `Number([])` are all 0, and `Number(true)` is 1. So
+ *    `getMonitor {monitorID: null}` did not fail — it silently read monitor 0. Junk arguments
+ *    became real IDs, which is the more damaging half.
+ *
+ * The fix keeps string IDs working (clients that stringify arguments are common) while
+ * rejecting everything that was previously coerced into a plausible-looking ID.
+ */
+
+type RegisteredTool = { inputSchema?: z.ZodObject<z.ZodRawShape> };
+
+let tools: Record<string, RegisteredTool>;
+
+beforeAll(async () => {
+  const { server } = await createServer({
+    url: 'http://localhost:3001',
+    username: undefined,
+    password: undefined,
+    token: undefined,
+    jwtToken: undefined,
+  });
+  tools = (server as unknown as { _registeredTools: Record<string, RegisteredTool> })._registeredTools;
+});
+
+/** The single issue reported against `field`, or undefined if the field was accepted. */
+function issueFor(toolName: string, args: Record<string, unknown>, field: string) {
+  const schema = tools[toolName].inputSchema!;
+  const result = schema.safeParse(args);
+  if (result.success) return undefined;
+  return result.error.issues.find((i) => i.path[0] === field);
+}
+
+describe('required ID arguments (#65)', () => {
+  it('reports an omitted monitorID as missing rather than as NaN', () => {
+    const issue = issueFor('getMonitor', {}, 'monitorID');
+
+    expect(issue).toBeDefined();
+    // The whole complaint of #65: the error described a NaN type mismatch instead of an
+    // absent field, sending the caller hunting for a type bug that was never there.
+    expect(JSON.stringify(issue)).not.toMatch(/nan/i);
+    expect(issue!.message).toMatch(/required|undefined|missing/i);
+  });
+
+  /**
+   * The exact reproduction from the issue. #70 made the unknown key the first thing reported,
+   * but the NaN line was still there underneath it; now the second line names the real
+   * consequence — the declared field ended up absent.
+   */
+  it('reports a misspelled monitorId without a NaN complaint underneath it', () => {
+    const result = tools.getMonitor.inputSchema!.safeParse({ monitorId: 1 });
+
+    expect(result.success).toBe(false);
+    const messages = (result as { error: z.ZodError }).error.issues.map((i) => i.message);
+    expect(messages[0]).toMatch(/monitorId/);
+    expect(messages.join('\n')).not.toMatch(/nan/i);
+  });
+
+  it.each([
+    ['null', null],
+    ['an empty string', ''],
+    ['an empty array', []],
+    ['a boolean', true],
+    ['a non-numeric string', 'abc'],
+    ['a float', 1.5],
+    ['a negative number', -1],
+  ])('rejects %s instead of coercing it into an ID', (_label, value) => {
+    expect(issueFor('getMonitor', { monitorID: value }, 'monitorID')).toBeDefined();
+  });
+
+  it('accepts a numeric ID', () => {
+    expect(tools.getMonitor.inputSchema!.safeParse({ monitorID: 7 }))
+      .toMatchObject({ success: true, data: { monitorID: 7 } });
+  });
+
+  it('accepts a stringified ID, for clients that stringify their arguments', () => {
+    expect(tools.getMonitor.inputSchema!.safeParse({ monitorID: '7' }))
+      .toMatchObject({ success: true, data: { monitorID: 7 } });
+  });
+
+  it('accepts zero, which is a valid ID', () => {
+    expect(tools.getMonitor.inputSchema!.safeParse({ monitorID: 0 }))
+      .toMatchObject({ success: true, data: { monitorID: 0 } });
+  });
+
+  /**
+   * The coercion was spelled the same way on every record ID, so fixing only the one named in
+   * the issue would leave the same trap on notifications, docker hosts and tags. Swept rather
+   * than listed so a tool added later cannot quietly reintroduce it.
+   */
+  it('holds for every required ID field on every tool', () => {
+    const idField = /(^|[a-z])ID$/;
+    const offenders: string[] = [];
+    let checked = 0;
+
+    for (const [toolName, tool] of Object.entries(tools)) {
+      const shape = tool.inputSchema?.shape;
+      if (!shape) continue;
+
+      for (const [field, fieldSchema] of Object.entries(shape)) {
+        if (!idField.test(field) || fieldSchema.isOptional()) continue;
+        checked++;
+
+        for (const junk of [null, '', [], true]) {
+          const result = tool.inputSchema!.safeParse({ [field]: junk });
+          const issue = result.success
+            ? undefined
+            : result.error.issues.find((i) => i.path[0] === field);
+          if (!issue) offenders.push(`${toolName}.${field} accepted ${JSON.stringify(junk)}`);
+        }
+
+        const missing = tool.inputSchema!.safeParse({});
+        const missingIssue = missing.success
+          ? undefined
+          : missing.error.issues.find((i) => i.path[0] === field);
+        if (missingIssue && /nan/i.test(JSON.stringify(missingIssue))) {
+          offenders.push(`${toolName}.${field} reports NaN when omitted`);
+        }
+      }
+    }
+
+    expect(checked).toBeGreaterThan(0);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/test/unit/monitor-parent-filter.test.ts
+++ b/test/unit/monitor-parent-filter.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import type { z } from 'zod';
 import { UptimeKumaClient } from '../../src/uptime-kuma-client.js';
+import { createServer } from '../../src/server.js';
 import { injectMonitorListCache } from './helpers.js';
 
 /**
@@ -55,5 +57,97 @@ describe('UptimeKumaClient - getMonitorList parentId filter', () => {
     const result = client.getMonitorList({ parentId: 1, type: 'http' });
     expect(Object.keys(result).sort()).toEqual(['2', '3']);
     expect(Object.keys(client.getMonitorList({ parentId: 1, type: 'group' })).length).toBe(0);
+  });
+});
+
+/**
+ * getMonitorSummary is the tool the instructions send callers to FIRST for status questions
+ * ("what's down?"), so "what's down in this group?" lands there rather than on listMonitors.
+ * The parent filter added for #65 only reached getMonitorList, so that question could not be
+ * asked of the one tool most likely to be asked it.
+ *
+ * The two functions each keep their own copy of the same filter loop, which is how they came
+ * to disagree in the first place — the same copy-paste divergence behind the rest of #65.
+ */
+describe('UptimeKumaClient - getMonitorSummary parentId filter', () => {
+  let client: UptimeKumaClient;
+
+  beforeEach(() => {
+    client = new UptimeKumaClient('http://localhost:3001');
+    injectMonitorListCache(client, {
+      '1': { id: 1, name: 'Group A', type: 'group', parent: null, pathName: 'Group A', active: true },
+      '2': { id: 2, name: 'Child A1', type: 'http', parent: 1, pathName: 'Group A / Child A1', active: true },
+      '3': { id: 3, name: 'Child A2', type: 'http', parent: 1, pathName: 'Group A / Child A2', active: true },
+      '4': { id: 4, name: 'Group B', type: 'group', parent: null, pathName: 'Group B', active: true },
+      '5': { id: 5, name: 'Child B1', type: 'http', parent: 4, pathName: 'Group B / Child B1', active: true },
+      '6': { id: 6, name: 'Grandchild', type: 'http', parent: 5, pathName: 'Group B / Child B1 / Grandchild', active: true },
+    });
+  });
+
+  const ids = (summaries: Array<{ id: number }>) => summaries.map((s) => s.id).sort((a, b) => a - b);
+
+  it('returns only the direct children of the given group', () => {
+    expect(ids(client.getMonitorSummary({ parentId: 1 }))).toEqual([2, 3]);
+  });
+
+  it('is not recursive — a grandchild is not returned', () => {
+    expect(ids(client.getMonitorSummary({ parentId: 4 }))).toEqual([5]);
+  });
+
+  it('parentId null returns only top-level monitors', () => {
+    expect(ids(client.getMonitorSummary({ parentId: null }))).toEqual([1, 4]);
+  });
+
+  it('omitting parentId returns everything (undefined is not the same as null)', () => {
+    expect(client.getMonitorSummary({}).length).toBe(6);
+    expect(client.getMonitorSummary().length).toBe(6);
+  });
+
+  it('parentId 0 is treated as a real id, not as "no filter"', () => {
+    expect(client.getMonitorSummary({ parentId: 0 }).length).toBe(0);
+  });
+
+  it('combines with other filters rather than replacing them', () => {
+    expect(ids(client.getMonitorSummary({ parentId: 1, type: 'http' }))).toEqual([2, 3]);
+    expect(client.getMonitorSummary({ parentId: 1, type: 'group' }).length).toBe(0);
+  });
+
+  it('agrees with getMonitorList about which monitors are in a group', () => {
+    for (const parentId of [null, 0, 1, 4, 5]) {
+      expect(ids(client.getMonitorSummary({ parentId })))
+        .toEqual(Object.keys(client.getMonitorList({ parentId })).map(Number).sort((a, b) => a - b));
+    }
+  });
+});
+
+/**
+ * The filter also has to survive the tool boundary: schemas are `.strict()`, so a `parentId`
+ * the tool does not declare is rejected outright no matter what the client supports.
+ */
+describe('parentId at the tool boundary', () => {
+  let tools: Record<string, { inputSchema?: z.ZodObject<z.ZodRawShape> }>;
+
+  beforeAll(async () => {
+    const { server } = await createServer({
+      url: 'http://localhost:3001',
+      username: undefined,
+      password: undefined,
+      token: undefined,
+      jwtToken: undefined,
+    });
+    tools = (server as unknown as { _registeredTools: typeof tools })._registeredTools;
+  });
+
+  it.each(['listMonitors', 'getMonitorSummary'])('%s accepts a group id and null', (toolName) => {
+    expect(tools[toolName].inputSchema!.safeParse({ parentId: 3 }))
+      .toMatchObject({ success: true, data: { parentId: 3 } });
+    expect(tools[toolName].inputSchema!.safeParse({ parentId: null }))
+      .toMatchObject({ success: true, data: { parentId: null } });
+  });
+
+  it.each(['listMonitors', 'getMonitorSummary'])('%s still distinguishes omitted from null', (toolName) => {
+    const parsed = tools[toolName].inputSchema!.safeParse({});
+    expect(parsed.success).toBe(true);
+    expect((parsed as { data: Record<string, unknown> }).data.parentId).toBeUndefined();
   });
 });

--- a/test/unit/numeric-argument-validation.test.ts
+++ b/test/unit/numeric-argument-validation.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { z } from 'zod';
+import { createServer } from '../../src/server.js';
+
+/**
+ * The write-path half of the coercion problem behind #65.
+ *
+ * Required record IDs were fixed first, but every OTHER numeric argument was still
+ * `z.coerce.number()`, and coercion runs `Number()` over whatever arrives:
+ * `Number(null)`, `Number('')` and `Number([])` are 0, and `Number(true)` is 1. On the read
+ * tools that returned the wrong record; on the write tools it STORES the wrong config.
+ *
+ * The motivating case is `timeout`. Its own field description warns that a stored 0 makes
+ * Uptime Kuma compute a ~13 hour timeout, so the monitor can never report DOWN against a host
+ * that accepts the connection and never answers. `.nullable()` happened to protect
+ * `timeout: null`, but nothing protected `timeout: ''` — which wrote exactly that 0 and
+ * silently disabled DOWN detection for the monitor.
+ */
+
+type RegisteredTool = { inputSchema?: z.ZodObject<z.ZodRawShape> };
+
+let tools: Record<string, RegisteredTool>;
+
+beforeAll(async () => {
+  const { server } = await createServer({
+    url: 'http://localhost:3001',
+    username: undefined,
+    password: undefined,
+    token: undefined,
+    jwtToken: undefined,
+  });
+  tools = (server as unknown as { _registeredTools: Record<string, RegisteredTool> })._registeredTools;
+});
+
+/**
+ * Unwraps optional/nullable/default/effect layers to ask what a field really is.
+ *
+ * Deliberately recognises numeric fields in BOTH spellings — the old `z.coerce.number()`
+ * (a bare ZodNumber) and the new preprocess wrapper (ZodEffects around a ZodNumber) — so the
+ * sweep below finds the same fields before and after the fix. A detector that only matched the
+ * new shape would find nothing in the old code and pass vacuously.
+ */
+function classify(schema: z.ZodTypeAny): { numeric: boolean; nullable: boolean } {
+  let current: z.ZodTypeAny = schema;
+  let nullable = false;
+
+  for (;;) {
+    if (current instanceof z.ZodOptional || current instanceof z.ZodNullable) {
+      if (current instanceof z.ZodNullable) nullable = true;
+      current = current.unwrap() as z.ZodTypeAny;
+      continue;
+    }
+    if (current instanceof z.ZodDefault) {
+      current = current.removeDefault() as z.ZodTypeAny;
+      continue;
+    }
+    if (current instanceof z.ZodEffects) {
+      current = current.innerType() as z.ZodTypeAny;
+      continue;
+    }
+    break;
+  }
+
+  if (current instanceof z.ZodUnion) {
+    const options = current.options as z.ZodTypeAny[];
+    const parts = options.map(classify);
+    return {
+      numeric: parts.some((p) => p.numeric),
+      nullable: nullable || options.some((o) => o instanceof z.ZodNull) || parts.some((p) => p.nullable),
+    };
+  }
+
+  return { numeric: current instanceof z.ZodNumber, nullable };
+}
+
+/** Every (tool, field) pair whose field accepts a number. */
+function numericFields(): Array<{ tool: string; field: string; nullable: boolean }> {
+  const found: Array<{ tool: string; field: string; nullable: boolean }> = [];
+  for (const [toolName, tool] of Object.entries(tools)) {
+    const shape = tool.inputSchema?.shape;
+    if (!shape) continue;
+    for (const [field, fieldSchema] of Object.entries(shape)) {
+      const { numeric, nullable } = classify(fieldSchema as z.ZodTypeAny);
+      if (numeric) found.push({ tool: toolName, field, nullable });
+    }
+  }
+  return found;
+}
+
+/** Parses `args`, returning the issue raised against `field`, if any. */
+function issueFor(toolName: string, field: string, value: unknown) {
+  // updateMonitor and friends need their own required ID present, or the only issue reported
+  // is the missing ID and the field under test is never reached.
+  const required: Record<string, unknown> = {
+    monitorID: 1,
+    notificationID: 1,
+    dockerHostID: 1,
+    tagID: 1,
+    name: 'x',
+    type: 'http',
+    title: 'x',
+    strategy: 'single',
+    active: true,
+  };
+  const args: Record<string, unknown> = {};
+  for (const [key] of Object.entries(tools[toolName].inputSchema!.shape)) {
+    if (key !== field && key in required) args[key] = required[key];
+  }
+  args[field] = value;
+
+  const result = tools[toolName].inputSchema!.safeParse(args);
+  if (result.success) return undefined;
+  return result.error.issues.find((i) => i.path[0] === field);
+}
+
+describe('numeric arguments reject junk instead of coercing it', () => {
+  it.each([
+    ['createMonitor', { name: 'x', type: 'http' }],
+    ['updateMonitor', { monitorID: 1 }],
+  ])('%s: timeout:"" does not become the 0 that disables DOWN detection', (tool, base) => {
+    const parsed = tools[tool].inputSchema!.safeParse({ ...base, timeout: '' });
+
+    // Guard against passing vacuously: if the whole object were rejected for an unrelated
+    // reason (a missing required field, a key the strict schema does not know), `timeout`
+    // would never be examined at all and the assertion below would prove nothing.
+    const timeoutIssue = parsed.success
+      ? undefined
+      : parsed.error.issues.find((i) => i.path[0] === 'timeout');
+    const otherIssues = parsed.success
+      ? []
+      : parsed.error.issues.filter((i) => i.path[0] !== 'timeout').map((i) => `${i.path.join('.')}: ${i.message}`);
+    expect(otherIssues, `${tool} rejected the fixture for an unrelated reason`).toEqual([]);
+
+    if (parsed.success) {
+      expect((parsed.data as { timeout?: unknown }).timeout, `${tool} coerced timeout:"" to 0`).not.toBe(0);
+    } else {
+      expect(timeoutIssue).toBeDefined();
+    }
+  });
+
+  it('timeout: null is still accepted, because null is a meaningful value there', () => {
+    const parsed = tools.updateMonitor.inputSchema!.safeParse({ monitorID: 1, timeout: null });
+    expect(parsed).toMatchObject({ success: true, data: { timeout: null } });
+  });
+
+  it('interval: junk does not silently become 0', () => {
+    for (const junk of [null, '', [], true]) {
+      expect(issueFor('updateMonitor', 'interval', junk), `interval accepted ${JSON.stringify(junk)}`)
+        .toBeDefined();
+    }
+  });
+
+  it('holds for every numeric field on every tool', () => {
+    const fields = numericFields();
+    expect(fields.length).toBeGreaterThan(10);
+
+    const offenders: string[] = [];
+    for (const { tool, field, nullable } of fields) {
+      // `null` is junk only where the field does not explicitly allow it.
+      const junkValues: unknown[] = nullable ? ['', [], true] : [null, '', [], true];
+      for (const junk of junkValues) {
+        if (!issueFor(tool, field, junk)) {
+          offenders.push(`${tool}.${field} accepted ${JSON.stringify(junk)}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('still accepts the values callers legitimately send', () => {
+    const cases: Array<[string, string, unknown, unknown]> = [
+      ['updateMonitor', 'interval', 60, 60],
+      ['updateMonitor', 'interval', '60', 60],
+      ['updateMonitor', 'interval', '  60  ', 60],
+      ['updateMonitor', 'timeout', 4.8, 4.8],
+      ['updateMonitor', 'timeout', '4.8', 4.8],
+      ['updateMonitor', 'parent', null, null],
+      ['getHeartbeats', 'maxHeartbeats', '10', 10],
+      ['listMonitors', 'parentId', '3', 3],
+      ['listMonitors', 'parentId', null, null],
+    ];
+    for (const [tool, field, input, expected] of cases) {
+      const args: Record<string, unknown> = { [field]: input };
+      if ('monitorID' in tools[tool].inputSchema!.shape) args.monitorID = 1;
+      const parsed = tools[tool].inputSchema!.safeParse(args);
+      expect(parsed.success, `${tool}.${field} rejected ${JSON.stringify(input)}`).toBe(true);
+      expect((parsed as { data: Record<string, unknown> }).data[field]).toBe(expected);
+    }
+  });
+
+  it('reports what actually arrived rather than a NaN', () => {
+    const issue = issueFor('updateMonitor', 'interval', null);
+    expect(JSON.stringify(issue)).not.toMatch(/nan/i);
+    expect(issue!.message).toMatch(/null/i);
+  });
+
+  /** Nested numerics are the easiest to miss, being neither top-level nor swept above. */
+  it('applies inside createMaintenance time ranges', () => {
+    const withHours = (hours: unknown) => tools.createMaintenance.inputSchema!.safeParse({
+      title: 'x',
+      strategy: 'recurring-interval',
+      timeRange: [{ hours, minutes: 0 }],
+    });
+    expect(withHours('').success, 'timeRange hours accepted ""').toBe(false);
+    expect(withHours(null).success, 'timeRange hours accepted null').toBe(false);
+    expect(withHours(9)).toMatchObject({ success: true });
+    expect(withHours('9')).toMatchObject({ success: true });
+  });
+});


### PR DESCRIPTION
Closes #65.

#69 and #70 addressed parts of #65. This finishes it, and follows the root cause into
territory the issue did not reach.

## 1. Required record IDs no longer coerce

#70 made a misspelled `monitorId` report the unknown key first, which fixed the reproduction
in the issue. It left the cause: `z.coerce.number()` on the required IDs. Coercion runs
`Number()` over whatever arrives, unconditionally, which costs twice.

**An absent field became NaN.** `getMonitor {}` reported "expected number, received nan" — a
type complaint about a field the caller never wrote. The `undefined` is destroyed before Zod
can ask whether the field was provided, so `.int()` and `.nonnegative()` never even run. The
reorder added in #70 only fires when there is an unknown key to hoist, so omitting the field
outright still produced the raw NaN, and the misspelling case still carried a NaN line
underneath.

**Junk became a plausible ID.** `Number(null)`, `Number('')` and `Number([])` are all 0, and
`Number(true)` is 1 — all of which pass `.int().nonnegative()` cleanly:

| input | before | after |
|---|---|---|
| omitted | `Expected number, received nan` | `...is required and was not provided` |
| `null` | ✅ read monitor **0** | `Expected number, received null` |
| `""` | ✅ read monitor **0** | `Expected number, received string` |
| `true` | ✅ read monitor **1** | `Expected number, received boolean` |
| `"7"` | ✅ `7` | ✅ `7` |

`getMonitor {monitorID: null}` did not error — it read monitor 0. On `deleteMonitor` that
shape of bug deletes the wrong thing. Sending `null` for an unset value is an ordinary thing
for a client to do.

The same declaration was copy-pasted across 11 tools, so this applied to monitors,
notifications, docker hosts and tags alike.

## 2. The same hole on every other numeric argument — including `timeout`

Fixing only the IDs would have left the more damaging half. On the write tools this stores
wrong config rather than returning the wrong record.

`timeout` is the case that matters. Its own field description warns that Uptime Kuma computes
a **~13 hour timeout** from a stored `0`, so the monitor can never report DOWN against a host
that accepts the connection and never answers. `.nullable()` happened to protect
`timeout: null` — nothing protected `timeout: ''`, which wrote exactly that 0. A monitor that
silently stops being able to report DOWN is the worst failure an uptime tool has, and an empty
string reached it through the front door.

The same hole was on `interval`, `retryInterval`, `resendInterval`, `port`, `maxretries`,
`maxredirects`, `docker_host`, `parent`, the heartbeat count aliases, the `parentId` filters
and the maintenance time fields.

`z.coerce.number()` is now gone from `server.ts`. The conversion is **conditional**: only
strings that parse to a finite number are converted, and everything else reaches the validator
unchanged, to be reported as what it actually was. Clients that stringify their arguments —
the reason the coercion existed — keep working. Chained `.nullable()` still short-circuits
ahead of the conversion, so fields where `null` is meaningful keep accepting it.

The advertised JSON Schema is unchanged throughout, verified field by field: constraints,
the nullable `anyOf` branches, and the numerics nested inside `createMaintenance`'s `timeRange`
array items all survive the effect wrapper.

## 3. `parentId` on `getMonitorSummary`, and docs for both

The parent filter from #69 reached `listMonitors` only. `getMonitorSummary` is the tool the
server instructions send callers to **first** for status questions, so "what's down in this
group?" arrives there — and it was the one tool that could not answer it. Schemas are strict,
so `parentId` was rejected outright.

The two functions each kept their own copy of the filter loop, which is how they came to
disagree. The subtle half is that `undefined` means "no filter" while `null` is a real,
requestable value meaning "top level only" — and `if (parentId)` conflates them *and* drops
group 0. Rather than copy that a second time it moves to a shared `matchesParentFilter`.

`parentId` was also absent from the README's filter list and from `listMonitors`' own tool
description, so it was undiscoverable from both places a caller looks. Both now document it.

## Testing

32 new tests. Every assertion was verified failing against the pre-fix code first — including
the sweeps, whose detectors deliberately match both the old and new schema spellings so they
find the fields in unfixed code rather than passing vacuously. The numeric sweep reported 87
offenders there.

Three sweeps guard the class rather than the instances, since this was one line copy-pasted
many times and reported as four separate bugs (#58, #60, #63, #65) because nothing connected
them:

- every required ID field on every tool rejects junk and reports absence as absence
- every numeric field on every tool rejects junk, with nullable fields still taking `null`
- `getMonitorSummary` and `getMonitorList` return the same monitors for the same `parentId`

The integration test for `timeout` asserts both halves: that `timeout: ''` is refused, **and**
that the stored value is still 240 afterward — rejecting loudly only counts if nothing was
written.

- **243 unit tests** passing
- **43 integration tests** passing against a live Uptime Kuma 2.x in Docker
- `tsc --noEmit` clean

## Note for review

`port: null` is now rejected rather than silently written as `0`. A caller doing read-edit-write
who passed `port: null` back for an HTTP monitor will see an error where they previously saw
success — but that success wrote `0`, not `null`, so the old behaviour was already wrong for
that intent. Making `port` nullable would be the fix if `null` should mean "no port", but that
changes what is written to Uptime Kuma and deserves its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
