### PR TITLE
fix: normalize Kuma response message values

### DIFF
--- a/src/types/heartbeat.ts
+++ b/src/types/heartbeat.ts
@@ -7,7 +7,14 @@ export const HeartbeatSchema = z.object({
   // Required fields
   status: z.number().describe('0=DOWN 1=UP 2=PENDING 3=MAINT'),
   time: z.string().describe('Timestamp, in UTC as "YYYY-MM-DD HH:mm:ss.SSS". Uptime Kuma sends no zone marker, so compare against the current UTC time, not local time.'),
-  msg: z.union([z.string(), z.array(z.any()).transform(arr => arr.join(', '))]).describe('Status message'),
+  msg: z.preprocess(
+    value => {
+      if (typeof value === 'number') return String(value);
+      if (Array.isArray(value)) return value.join(', ');
+      return value;
+    },
+    z.string()
+  ).describe('Status message'),
   important: z.union([z.boolean(), z.number()]).transform(val => Boolean(val)).describe('Status change flag'),
   // Optional fields
   id: z.number().optional().describe('Heartbeat ID'),

--- a/src/types/heartbeat.ts
+++ b/src/types/heartbeat.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { normaliseMsg } from '../utils/normalize-msg.js';
 
 /**
  * Zod schema for Heartbeat object structure from Uptime Kuma
@@ -7,14 +8,7 @@ export const HeartbeatSchema = z.object({
   // Required fields
   status: z.number().describe('0=DOWN 1=UP 2=PENDING 3=MAINT'),
   time: z.string().describe('Timestamp, in UTC as "YYYY-MM-DD HH:mm:ss.SSS". Uptime Kuma sends no zone marker, so compare against the current UTC time, not local time.'),
-  msg: z.preprocess(
-    value => {
-      if (typeof value === 'number') return String(value);
-      if (Array.isArray(value)) return value.join(', ');
-      return value;
-    },
-    z.string()
-  ).describe('Status message'),
+  msg: z.preprocess(normaliseMsg, z.string()).describe('Status message'),
   important: z.union([z.boolean(), z.number()]).transform(val => Boolean(val)).describe('Status change flag'),
   // Optional fields
   id: z.number().optional().describe('Heartbeat ID'),

--- a/src/types/monitor-base.ts
+++ b/src/types/monitor-base.ts
@@ -16,7 +16,14 @@ export const MonitorSummarySchema = z.object({
   uptime: z.record(z.string(), z.number()).optional().describe('Uptime % by period (24h/720h/1y)'),
   avgPing: z.number().nullable().optional().describe('24h average ping (ms)'),
   status: z.number().optional().describe('0=DOWN 1=UP 2=PENDING 3=MAINT'),
-  msg: z.string().optional().describe('Latest status message'),
+  msg: z.preprocess(
+    value => {
+      if (typeof value === 'number') return String(value);
+      if (Array.isArray(value)) return value.join(', ');
+      return value;
+    },
+    z.string().optional()
+  ).describe('Latest status message'),
   lastBeatTime: z.string().nullable().optional().describe('Timestamp of the heartbeat that `status` and `msg` come from, in UTC as "YYYY-MM-DD HH:mm:ss.SSS" — Uptime Kuma sends no zone marker, so compare it against the current UTC time, not local time. Check this before trusting the status of a push monitor: one that has stopped beating reports its last known status indefinitely, and is otherwise indistinguishable from a healthy one.'),
 });
 

--- a/src/types/monitor-base.ts
+++ b/src/types/monitor-base.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { MonitorTagSchema } from './tags.js';
 import { MonitorConditionSchema } from './monitor-conditions.js';
+import { normaliseMsg } from '../utils/normalize-msg.js';
 
 /**
  * Monitor Summary schema (for list views)
@@ -16,14 +17,7 @@ export const MonitorSummarySchema = z.object({
   uptime: z.record(z.string(), z.number()).optional().describe('Uptime % by period (24h/720h/1y)'),
   avgPing: z.number().nullable().optional().describe('24h average ping (ms)'),
   status: z.number().optional().describe('0=DOWN 1=UP 2=PENDING 3=MAINT'),
-  msg: z.preprocess(
-    value => {
-      if (typeof value === 'number') return String(value);
-      if (Array.isArray(value)) return value.join(', ');
-      return value;
-    },
-    z.string().optional()
-  ).describe('Latest status message'),
+  msg: z.preprocess(normaliseMsg, z.string().optional()).describe('Latest status message'),
   lastBeatTime: z.string().nullable().optional().describe('Timestamp of the heartbeat that `status` and `msg` come from, in UTC as "YYYY-MM-DD HH:mm:ss.SSS" — Uptime Kuma sends no zone marker, so compare it against the current UTC time, not local time. Check this before trusting the status of a push monitor: one that has stopped beating reports its last known status indefinitely, and is otherwise indistinguishable from a healthy one.'),
 });
 

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -11,6 +11,7 @@ export const SettingsSchema = z.object({
   entryPage: z.string().optional().describe('Entry page (dashboard/statuspage)'),
   dnsCache: z.boolean().optional().describe('DNS cache enabled'),
   keepDataPeriodDays: z.number().optional().describe('Data retention period (days)'),
+  domainExpiryNotifyDays: z.array(z.number()).optional().describe('Domain expiry notification days'),
   tlsExpiryNotifyDays: z.array(z.number()).optional().describe('TLS expiry notification days'),
   trustProxy: z.boolean().optional().describe('Trust proxy headers'),
   nscd: z.boolean().optional().describe('NSCD enabled'),

--- a/src/uptime-kuma-client.ts
+++ b/src/uptime-kuma-client.ts
@@ -479,10 +479,22 @@ export class UptimeKumaClient {
    * nothing here: the `heartbeatList` handler replaces the cached array wholesale rather
    * than merging into it, so the persisted copy never lands beside the live one.
    */
+  static normaliseHeartbeat(beat: Heartbeat): Heartbeat {
+    const rawMsg = (beat as Heartbeat & { msg: unknown }).msg;
+    const msg = typeof rawMsg === 'number'
+      ? String(rawMsg)
+      : Array.isArray(rawMsg)
+        ? rawMsg.join(', ')
+        : rawMsg;
+
+    return msg === rawMsg ? beat : { ...beat, msg };
+  }
+
   static normaliseBeats(list: Heartbeat[]): Heartbeat[] {
     const seen = new Set<string>();
     const deduped: Heartbeat[] = [];
-    for (const beat of list) {
+    for (const rawBeat of list) {
+      const beat = UptimeKumaClient.normaliseHeartbeat(rawBeat);
       const key =
         typeof beat?.id === 'number'
           ? `id:${beat.id}`
@@ -520,7 +532,8 @@ export class UptimeKumaClient {
     });
 
     // Listen for individual heartbeat updates (real-time)
-    this.socket.on('heartbeat', (heartbeat: Heartbeat) => {
+    this.socket.on('heartbeat', (rawHeartbeat: Heartbeat) => {
+      const heartbeat = UptimeKumaClient.normaliseHeartbeat(rawHeartbeat);
       // The heartbeat event should always include monitorID
       if (!heartbeat.monitorID) {
         this.safeLog('warning', 'Received heartbeat without monitorID');
@@ -754,7 +767,7 @@ export class UptimeKumaClient {
     const result: { [monitorID: string]: Heartbeat[] } = {};
     
     for (const [monitorID, heartbeats] of Object.entries(this.heartbeatListCache)) {
-      result[monitorID] = heartbeats.slice(0, maxHeartbeats);
+      result[monitorID] = heartbeats.slice(0, maxHeartbeats).map(UptimeKumaClient.normaliseHeartbeat);
     }
     
     return result;
@@ -774,7 +787,7 @@ export class UptimeKumaClient {
       return [];
     }
     
-    return heartbeats.slice(0, maxHeartbeats);
+    return heartbeats.slice(0, maxHeartbeats).map(UptimeKumaClient.normaliseHeartbeat);
   }
 
   /**
@@ -788,7 +801,9 @@ export class UptimeKumaClient {
    */
   getLatestHeartbeat(monitorID: number): Heartbeat | undefined {
     const heartbeats = this.heartbeatListCache[monitorID.toString()];
-    return heartbeats && heartbeats.length > 0 ? heartbeats[0] : undefined;
+    return heartbeats && heartbeats.length > 0
+      ? UptimeKumaClient.normaliseHeartbeat(heartbeats[0])
+      : undefined;
   }
 
   /**

--- a/src/uptime-kuma-client.ts
+++ b/src/uptime-kuma-client.ts
@@ -21,6 +21,7 @@ import type {
   StatusPage,
   DockerHost,
 } from './types/index.js';
+import { normaliseMsg } from './utils/normalize-msg.js';
 
 /**
  * How long a post-write read-back waits for the server's acknowledgement before giving up.
@@ -481,13 +482,9 @@ export class UptimeKumaClient {
    */
   static normaliseHeartbeat(beat: Heartbeat): Heartbeat {
     const rawMsg = (beat as Heartbeat & { msg: unknown }).msg;
-    const msg = typeof rawMsg === 'number'
-      ? String(rawMsg)
-      : Array.isArray(rawMsg)
-        ? rawMsg.join(', ')
-        : rawMsg;
+    const msg = normaliseMsg(rawMsg);
 
-    return msg === rawMsg ? beat : { ...beat, msg };
+    return msg === rawMsg ? beat : { ...beat, msg: msg as Heartbeat['msg'] };
   }
 
   static normaliseBeats(list: Heartbeat[]): Heartbeat[] {

--- a/src/utils/normalize-msg.ts
+++ b/src/utils/normalize-msg.ts
@@ -1,0 +1,10 @@
+/**
+ * Uptime Kuma sends `msg` as a string in most cases, but some monitor types (e.g. push
+ * monitors with no message) or intermediate socket.io payloads can carry it as a number
+ * or an array of strings instead. Coerce those into the plain string shape callers expect.
+ */
+export function normaliseMsg(value: unknown): unknown {
+  if (typeof value === 'number') return String(value);
+  if (Array.isArray(value)) return value.join(', ');
+  return value;
+}

--- a/test/unit/heartbeats.test.ts
+++ b/test/unit/heartbeats.test.ts
@@ -54,6 +54,19 @@ describe('UptimeKumaClient - Heartbeat Operations', () => {
       const result = client.getHeartbeatList(10);
       expect(result['1']).toHaveLength(1);
     });
+
+    it('normalizes numeric and array messages before returning heartbeats', () => {
+      injectHeartbeatListCache(client, {
+        '1': [
+          { monitorID: 1, status: 1, msg: 200, time: '2024-01-02' },
+          { monitorID: 1, status: 1, msg: ['HTTP 200', 'OK'], time: '2024-01-01' },
+        ],
+      });
+
+      const result = client.getHeartbeatList(2);
+
+      expect(result['1'].map((beat) => beat.msg)).toEqual(['200', 'HTTP 200, OK']);
+    });
   });
 
   describe('getHeartbeatsForMonitor', () => {

--- a/test/unit/monitor-summary-schema.test.ts
+++ b/test/unit/monitor-summary-schema.test.ts
@@ -22,4 +22,8 @@ describe('MonitorSummarySchema status messages', () => {
 
     expect(result.msg).toBe('HTTP 500, retrying');
   });
+
+  it('rejects unrelated invalid monitor summary data', () => {
+    expect(() => MonitorSummarySchema.parse({ ...summary, id: 'not-a-number' })).toThrow();
+  });
 });

--- a/test/unit/monitor-summary-schema.test.ts
+++ b/test/unit/monitor-summary-schema.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { MonitorSummarySchema } from '../../src/types/monitor-base.js';
+
+describe('MonitorSummarySchema status messages', () => {
+  const summary = {
+    id: 1,
+    name: 'Monitor',
+    type: 'http',
+    active: true,
+    pathName: 'Monitor',
+    maintenance: false,
+  };
+
+  it('normalizes numeric heartbeat messages to strings', () => {
+    const result = MonitorSummarySchema.parse({ ...summary, msg: 42 });
+
+    expect(result.msg).toBe('42');
+  });
+
+  it('normalizes heartbeat message arrays to strings', () => {
+    const result = MonitorSummarySchema.parse({ ...summary, msg: ['HTTP 500', 'retrying'] });
+
+    expect(result.msg).toBe('HTTP 500, retrying');
+  });
+});

--- a/test/unit/monitors.test.ts
+++ b/test/unit/monitors.test.ts
@@ -427,6 +427,17 @@ describe('UptimeKumaClient - Monitor CRUD Operations', () => {
       expect(web?.msg).toBe('OK');
     });
 
+    it('normalizes non-string heartbeat messages before returning summaries', () => {
+      injectHeartbeatListCache(client, {
+        '1': [{ monitorID: 1, status: 1, msg: 200, ping: 50, time: '2024-01-01' },
+          { monitorID: 1, status: 1, msg: ['HTTP 200', 'OK'], ping: 50, time: '2023-12-31' }],
+      });
+
+      const summary = client.getMonitorSummary()[0];
+
+      expect(summary.msg).toBe('200');
+    });
+
     it('filters by status', () => {
       const down = client.getMonitorSummary({ status: '0' });
       expect(down).toHaveLength(1);

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { UptimeKumaClient } from '../../src/uptime-kuma-client.js';
+import { SettingsSchema } from '../../src/types/settings.js';
 import { createMockSocket, createDisconnectedSocket, injectSocket, injectStatusPageListCache } from './helpers.js';
 
 describe('UptimeKumaClient - Settings Operations', () => {
@@ -7,6 +8,12 @@ describe('UptimeKumaClient - Settings Operations', () => {
 
   beforeEach(() => {
     client = new UptimeKumaClient('http://localhost:3001');
+  });
+
+  it('accepts current Uptime Kuma domain expiry settings', () => {
+    const result = SettingsSchema.parse({ domainExpiryNotifyDays: [7, 14, 21] });
+
+    expect(result.domainExpiryNotifyDays).toEqual([7, 14, 21]);
   });
 
   describe('getSettings', () => {


### PR DESCRIPTION
## Summary
- Normalize numeric and array-valued heartbeat messages at the client/output boundary.
- Extend heartbeat validation for the values returned by Uptime Kuma.
- Accept the current `domainExpiryNotifyDays` setting.
- Add regression coverage for summaries, heartbeats, and settings.

This fixes MCP output-validation failures observed with live Uptime Kuma responses.

## Verification
- `npm test` — 19 files, 249 tests passed
- `npm run build` — passed
- `git diff --check` — passed