### PR TITLE
fix(http): support TRUST_PROXY for rate limiting behind a reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ upgrading cannot break an existing deployment - the server warns at startup in t
 | `ALLOWED_ORIGIN` | `*` (no validation) | Comma-separated list of browser origins permitted to call `/mcp`. A request whose `Origin` is not listed gets `403`. Requests with no `Origin` header (every native MCP client) are always allowed. |
 | `HOST` | `0.0.0.0` | Address to bind. Set to `127.0.0.1` when running locally outside a container. |
 | `PORT` | `3000` | Port to listen on. |
+| `TRUST_PROXY` | unset (no trust) | Trust `X-Forwarded-For` from a reverse proxy in front of the server, so the rate limiter keys on the real client IP instead of the proxy's. Accepts a hop count (`1`), `true`/`false`, or an IP/subnet list - see [Express's `trust proxy` docs](https://expressjs.com/en/guide/behind-proxies.html). |
 
 `/health` is deliberately left unauthenticated so container healthchecks and load balancer
 probes keep working. It reports nothing but liveness.
@@ -268,6 +269,24 @@ clients send no `Origin` header. If you use a browser-based client, list its ori
 ```
 ALLOWED_ORIGIN=https://librechat.example.com,http://localhost:5173
 ```
+
+### Running behind a reverse proxy
+
+Without `TRUST_PROXY`, Express sees every request as coming from the proxy's IP, so the
+rate limiter puts all of your clients in one shared 100-request bucket and starts
+returning spurious `429`s once traffic from any of them adds up.
+
+Set `TRUST_PROXY` to the number of proxy hops in front of the server so it reads the
+real client IP from `X-Forwarded-For` instead:
+
+```
+TRUST_PROXY=1
+```
+
+Only set this when a proxy you control is actually there to strip and re-set that
+header. If the server is reachable directly as well, or the proxy passes through
+whatever `X-Forwarded-For` it receives, a client can forge that header to get a fresh
+rate-limit bucket on every request, defeating the limiter entirely.
 
 ## Credential Redaction
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,8 @@ Environment variables for the streamable HTTP transport:
   ALLOWED_ORIGIN   Comma-separated origins allowed to call /mcp. Default '*' = no validation.
   HOST             Address to bind. Default '0.0.0.0'; use '127.0.0.1' for local-only.
   PORT             Port to listen on. Default 3000.
+  TRUST_PROXY      Trust reverse-proxy headers (X-Forwarded-For) for rate limiting.
+                   Hop count ('1'), 'true'/'false', or IP/subnet list. Unset = no trust.
 `);
       process.exit(0);
     }
@@ -140,6 +142,27 @@ async function runStdio(config: UptimeKumaConfig) {
 async function runHttp(config: UptimeKumaConfig) {
   const app = express();
   app.use(express.json());
+
+  // When running behind a reverse proxy (ingress, load balancer, sidecar proxy),
+  // set TRUST_PROXY so express-rate-limit derives the real client IP from
+  // X-Forwarded-For. Without it, express-rate-limit v7 throws
+  // ERR_ERL_UNEXPECTED_X_FORWARDED_FOR and every client is rate-limited under the
+  // single proxy IP. Accepts a hop count ("1"), "true"/"false", or an IP/subnet list.
+  // Defaults to Express's built-in behaviour (no trust) when unset — secure by default.
+  const trustProxy = process.env.TRUST_PROXY;
+  if (trustProxy !== undefined && trustProxy !== '') {
+    const numericHops = Number(trustProxy);
+    app.set(
+      'trust proxy',
+      trustProxy === 'true'
+        ? true
+        : trustProxy === 'false'
+          ? false
+          : Number.isNaN(numericHops)
+            ? trustProxy
+            : numericHops
+    );
+  }
 
   const allowedOrigins = parseAllowedOrigins(process.env.ALLOWED_ORIGIN);
   const authToken = process.env.MCP_AUTH_TOKEN;

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,9 +145,12 @@ async function runHttp(config: UptimeKumaConfig) {
 
   // When running behind a reverse proxy (ingress, load balancer, sidecar proxy),
   // set TRUST_PROXY so express-rate-limit derives the real client IP from
-  // X-Forwarded-For. Without it, express-rate-limit v7 throws
-  // ERR_ERL_UNEXPECTED_X_FORWARDED_FOR and every client is rate-limited under the
-  // single proxy IP. Accepts a hop count ("1"), "true"/"false", or an IP/subnet list.
+  // X-Forwarded-For. Without it req.ip is the proxy's address, so every client
+  // shares a single rate-limit bucket and all of them start getting 429s.
+  // (express-rate-limit also logs ERR_ERL_UNEXPECTED_X_FORWARDED_FOR in that case —
+  // its validations wrapper catches the error and console.errors it, so it is a
+  // diagnostic signal rather than the failure itself.)
+  // Accepts a hop count ("1"), "true"/"false", or an IP/subnet list.
   // Defaults to Express's built-in behaviour (no trust) when unset — secure by default.
   const trustProxy = process.env.TRUST_PROXY;
   if (trustProxy !== undefined && trustProxy !== '') {


### PR DESCRIPTION
Fixes #89.

### Problem

Behind a reverse proxy, Express `trust proxy` is never set, so `req.ip` resolves to the proxy's address. `express-rate-limit` then keys every caller to that single IP, they all share one 100-req/15-min bucket, and the server returns spurious `429`s.

Secondary signal: the library's `xForwardedForHeader` validation raises `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` when `X-Forwarded-For` is present while `trust proxy` is `false`. In v8.2.1 that error is caught by the validations wrapper and logged via `console.error`, so it is a diagnostic hint rather than the failure itself.

### Change

Add an optional **`TRUST_PROXY`** env var in `runHttp`, passed to `app.set('trust proxy', …)` before the rate limiter. It accepts:
- a hop count (`"1"`),
- `"true"` / `"false"`,
- an IP/subnet list.

**Unset keeps the current behaviour (no trust)** — secure by default, no change for stdio or direct-exposure users. Documented in the CLI `--help` env section.

### Notes

- Draft: opening for feedback on the approach/naming before finalising. I haven't run the build locally in this environment; happy to adjust style (e.g. parse helper, validation) to match your preferences.
- Tested conceptually against the reported setup (ToolHive proxy + Traefik ingress); with `TRUST_PROXY=1` the limiter keys off the real client IP instead of the proxy IP.
- Correction to the first version of this PR and of #89: both said `express-rate-limit` **v7**. `package.json` pins `^8.2.1`; I have since read v8.2.1's `validations.ts` and confirmed the check is still there, but that it is caught and logged rather than thrown. The code comment has been amended accordingly.
